### PR TITLE
fix: dock devtools at bottom

### DIFF
--- a/packages/main-process/src/parts/ElectronWindow/ElectronWindow.ts
+++ b/packages/main-process/src/parts/ElectronWindow/ElectronWindow.ts
@@ -3,6 +3,9 @@ import * as GetWindowById from '../GetWindowById/GetWindowById.ts'
 import * as Logger from '../Logger/Logger.ts'
 
 const devtoolsBeforeInputListeners = new WeakMap<any, any>()
+const devtoolsOptions = {
+  mode: 'bottom',
+}
 
 const isToggleDevtoolsInput = (input) => {
   if (input.type !== 'keyDown') {
@@ -72,7 +75,7 @@ const toggleDevtools = (browserWindow) => {
       attachDevtoolsKeyListener(browserWindow)
     })
   }
-  browserWindow.webContents.openDevTools()
+  browserWindow.webContents.openDevTools(devtoolsOptions)
 }
 
 export const executeWindowFunction = (browserWindowId, key) => {

--- a/packages/main-process/test/ElectronWindow.test.ts
+++ b/packages/main-process/test/ElectronWindow.test.ts
@@ -92,6 +92,9 @@ test('executeWindowFunction - toggleDevtools - opens and closes from focused dev
   ElectronWindow.executeWindowFunction(1, 'toggleDevtools')
 
   expect(pageWebContents.openDevTools).toHaveBeenCalledTimes(1)
+  expect(pageWebContents.openDevTools).toHaveBeenCalledWith({
+    mode: 'bottom',
+  })
   expect(devtoolsWebContents.on).toHaveBeenCalledTimes(1)
   expect(devtoolsWebContents.on).toHaveBeenCalledWith('before-input-event', expect.any(Function))
   expect(devtoolsClosedListener).toEqual(expect.any(Function))


### PR DESCRIPTION
Opens app DevTools with Electron's bottom docking mode while preserving the existing toggle behavior.