### PR TITLE
fix: expose packaged deb state

### DIFF
--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -5,6 +5,7 @@ import * as CreateMessagePort from '../CreateMessagePort/CreateMessagePort.ts'
 import * as CreatePidMap from '../CreatePidMap/CreatePidMap.ts'
 import * as CreateUtilityProcessRpc from '../CreateUtilityProcessRpc/CreateUtilityProcessRpc.ts'
 import * as DesktopCapturer from '../DesktopCapturer/DesktopCapturer.ts'
+import * as ElectronApp from '../ElectronApp/ElectronApp.ts'
 import * as ElectronApplicationMenu from '../ElectronApplicationMenu/ElectronApplicationMenu.ts'
 import * as ElectronBeep from '../ElectronBeep/ElectronBeep.ts'
 import * as ElectronContentTracing from '../ElectronContentTracing/ElectronContentTracing.ts'
@@ -40,6 +41,7 @@ export const commandMap = {
   'CreatePidMap.createPidMap': CreatePidMap.createPidMap,
   'CreateUtilityProcessRpc.createUtilityProcessRpc': CreateUtilityProcessRpc.createUtilityProcessRpc,
   'DesktopCapturer.getSources': DesktopCapturer.getSources,
+  'ElectronApp.isPackagedDeb': ElectronApp.isPackagedDeb,
   'ElectronApplicationMenu.setItems': ElectronApplicationMenu.setItems,
   'ElectronBeep.beep': ElectronBeep.beep,
   'ElectronContentTracing.startRecording': ElectronContentTracing.startRecording,

--- a/packages/main-process/src/parts/ElectronApp/ElectronApp.ts
+++ b/packages/main-process/src/parts/ElectronApp/ElectronApp.ts
@@ -19,3 +19,7 @@ export const appendCommandLineSwitch = (commandLineSwitch, value) => {
 export const exit = (code) => {
   app.exit(code)
 }
+
+export const isPackagedDeb = () => {
+  return app.isPackaged && process.platform === 'linux' && !process.env.APPIMAGE
+}

--- a/packages/main-process/test/ElectronApp.test.ts
+++ b/packages/main-process/test/ElectronApp.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+
+const electronApp = {
+  commandLine: {
+    appendSwitch: jest.fn(),
+  },
+  exit: jest.fn(),
+  isPackaged: true,
+  on: jest.fn(),
+  quit: jest.fn(),
+  whenReady: jest.fn(),
+}
+
+jest.unstable_mockModule('electron', () => {
+  return {
+    app: electronApp,
+  }
+})
+
+const ElectronApp = await import('../src/parts/ElectronApp/ElectronApp.ts')
+const originalPlatform = process.platform
+
+const setPlatform = (platform: NodeJS.Platform): void => {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+  })
+}
+
+beforeEach(() => {
+  setPlatform('linux')
+})
+
+afterEach(() => {
+  delete process.env.APPIMAGE
+  electronApp.isPackaged = true
+  setPlatform(originalPlatform)
+})
+
+test('isPackagedDeb', () => {
+  expect(ElectronApp.isPackagedDeb()).toBe(true)
+})
+
+test('isPackagedDeb - not packaged', () => {
+  electronApp.isPackaged = false
+
+  expect(ElectronApp.isPackagedDeb()).toBe(false)
+})
+
+test('isPackagedDeb - appimage', () => {
+  process.env.APPIMAGE = '/test/Lvce.AppImage'
+
+  expect(ElectronApp.isPackagedDeb()).toBe(false)
+})
+
+test('isPackagedDeb - windows', () => {
+  setPlatform('win32')
+
+  expect(ElectronApp.isPackagedDeb()).toBe(false)
+})


### PR DESCRIPTION
Adds a main-process ElectronApp.isPackagedDeb command so other processes can query packaged deb state.