### PR TITLE
feature: show gpu info

### DIFF
--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -23,6 +23,7 @@ import * as ElectronWebContents from '../ElectronWebContents/ElectronWebContents
 import * as ElectronWebContentsView from '../ElectronWebContentsView/ElectronWebContentsView.ts'
 import * as ElectronWebContentsViewFunctions from '../ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.ts'
 import * as ElectronWindow from '../ElectronWindow/ElectronWindow.ts'
+import * as ElectronWindowGpuInfo from '../ElectronWindowGpuInfo/ElectronWindowGpuInfo.ts'
 import * as ElectronWindowProcessExplorer from '../ElectronWindowProcessExplorer/ElectronWindowProcessExplorer.ts'
 import * as Exit from '../Exit/Exit.ts'
 import * as GetWindowId from '../GetWindowId/GetWindowId.ts'
@@ -123,6 +124,7 @@ export const commandMap = {
   'ElectronWindow.executeWindowFunction': ElectronWindow.executeWindowFunction,
   'ElectronWindow.getFocusedWindowId': ElectronWindow.getFocusedWindowId,
   'ElectronWindow.getZoom': ElectronWindow.getZoom,
+  'ElectronWindowGpuInfo.open': ElectronWindowGpuInfo.open,
   'ElectronWindowProcessExplorer.open2': ElectronWindowProcessExplorer.open2,
   'Exit.exit': Exit.exit,
   'GetWindowId.getWindowId': GetWindowId.getWindowId,

--- a/packages/main-process/src/parts/ElectronWindowGpuInfo/ElectronWindowGpuInfo.ts
+++ b/packages/main-process/src/parts/ElectronWindowGpuInfo/ElectronWindowGpuInfo.ts
@@ -1,0 +1,28 @@
+import { BrowserWindow } from 'electron'
+
+const gpuInfoUrl = 'chrome://gpu'
+let gpuInfoWindow: BrowserWindow | undefined
+
+export const open = async (): Promise<void> => {
+  if (gpuInfoWindow) {
+    gpuInfoWindow.focus()
+    return
+  }
+  gpuInfoWindow = new BrowserWindow({
+    height: 800,
+    title: 'GPU Internals',
+    webPreferences: {
+      sandbox: true,
+      spellcheck: false,
+    },
+    width: 1200,
+  })
+  const currentGpuInfoWindow = gpuInfoWindow
+  gpuInfoWindow.once('closed', () => {
+    if (gpuInfoWindow === currentGpuInfoWindow) {
+      gpuInfoWindow = undefined
+    }
+  })
+  gpuInfoWindow.setMenuBarVisibility(false)
+  await gpuInfoWindow.loadURL(gpuInfoUrl)
+}

--- a/packages/main-process/test/ElectronWindowGpuInfo.test.ts
+++ b/packages/main-process/test/ElectronWindowGpuInfo.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import EventEmitter from 'node:events'
+
+const browserWindows: any[] = []
+
+jest.unstable_mockModule('electron', () => {
+  class BrowserWindow extends EventEmitter {
+    focus = jest.fn()
+    loadURL = jest.fn()
+    setMenuBarVisibility = jest.fn()
+
+    constructor(public readonly options: Electron.BrowserWindowConstructorOptions) {
+      super()
+      browserWindows.push(this)
+    }
+  }
+
+  return {
+    BrowserWindow,
+  }
+})
+
+const ElectronWindowGpuInfo = await import('../src/parts/ElectronWindowGpuInfo/ElectronWindowGpuInfo.ts')
+
+beforeEach(() => {
+  browserWindows.length = 0
+  jest.clearAllMocks()
+})
+
+test('open', async () => {
+  await ElectronWindowGpuInfo.open()
+
+  expect(browserWindows).toHaveLength(1)
+  expect(browserWindows[0].options).toEqual({
+    height: 800,
+    title: 'GPU Internals',
+    webPreferences: {
+      sandbox: true,
+      spellcheck: false,
+    },
+    width: 1200,
+  })
+  expect(browserWindows[0].setMenuBarVisibility).toHaveBeenCalledTimes(1)
+  expect(browserWindows[0].setMenuBarVisibility).toHaveBeenCalledWith(false)
+  expect(browserWindows[0].loadURL).toHaveBeenCalledTimes(1)
+  expect(browserWindows[0].loadURL).toHaveBeenCalledWith('chrome://gpu')
+
+  await ElectronWindowGpuInfo.open()
+
+  expect(browserWindows).toHaveLength(1)
+  expect(browserWindows[0].focus).toHaveBeenCalledTimes(1)
+
+  browserWindows[0].emit('closed')
+  await ElectronWindowGpuInfo.open()
+
+  expect(browserWindows).toHaveLength(2)
+})


### PR DESCRIPTION
Adds a dedicated GPU diagnostics window backed by Chromium's GPU internals page. Reuses and focuses the window on repeated commands.