### PR TITLE
fix: improve utility process names

### DIFF
--- a/packages/main-process/src/parts/CreateElectronUtilityProcessRpc/CreateElectronUtilityProcessRpc.ts
+++ b/packages/main-process/src/parts/CreateElectronUtilityProcessRpc/CreateElectronUtilityProcessRpc.ts
@@ -1,0 +1,15 @@
+import { ElectronUtilityProcessRpcParent } from '@lvce-editor/rpc'
+import * as TrackUtilityProcess from '../TrackUtilityProcess/TrackUtilityProcess.ts'
+
+interface RpcWithRawIpc {
+  readonly ipc?: {
+    readonly _rawIpc?: unknown
+  }
+}
+
+export const createElectronUtilityProcessRpc = async (options: any): Promise<any> => {
+  const rpc = await ElectronUtilityProcessRpcParent.create(options)
+  const rpcWithRawIpc = rpc as RpcWithRawIpc
+  TrackUtilityProcess.trackUtilityProcess(rpcWithRawIpc.ipc?._rawIpc, options.name)
+  return rpc
+}

--- a/packages/main-process/src/parts/CreateUtilityProcessRpc/CreateUtilityProcessRpc.ts
+++ b/packages/main-process/src/parts/CreateUtilityProcessRpc/CreateUtilityProcessRpc.ts
@@ -1,9 +1,9 @@
-import { ElectronUtilityProcessRpcParent } from '@lvce-editor/rpc'
 import * as RpcRegistry from '@lvce-editor/rpc-registry'
 import * as CommandMapRef from '../CommandMapRef/CommandMapRef.ts'
+import * as CreateElectronUtilityProcessRpc from '../CreateElectronUtilityProcessRpc/CreateElectronUtilityProcessRpc.ts'
 
 export const createUtilityProcessRpc = async (options) => {
-  const rpc = await ElectronUtilityProcessRpcParent.create({
+  const rpc = await CreateElectronUtilityProcessRpc.createElectronUtilityProcessRpc({
     commandMap: CommandMapRef.commandMapRef,
     ...options,
   })

--- a/packages/main-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
+++ b/packages/main-process/src/parts/IpcParentWithElectronUtilityProcess/IpcParentWithElectronUtilityProcess.ts
@@ -1,24 +1,10 @@
 import { IpcParentWithElectronUtilityProcess } from '@lvce-editor/ipc'
-import * as FormatUtilityProcessName from '../FormatUtilityProcessName/FormatUtilityProcessName.ts'
-import * as UtilityProcessState from '../UtilityProcessState/UtilityProcessState.ts'
+import * as TrackUtilityProcess from '../TrackUtilityProcess/TrackUtilityProcess.ts'
 
 export const { create } = IpcParentWithElectronUtilityProcess
 
 export const { wrap } = IpcParentWithElectronUtilityProcess
 
 export const effects = ({ name, rawIpc }) => {
-  if (!rawIpc.pid) {
-    return
-  }
-  const { pid } = rawIpc
-  const formattedName = FormatUtilityProcessName.formatUtilityProcessName(name)
-  UtilityProcessState.add(pid, rawIpc, formattedName)
-  const cleanup = () => {
-    UtilityProcessState.remove(pid)
-    rawIpc.off('exit', handleExit)
-  }
-  const handleExit = () => {
-    cleanup()
-  }
-  rawIpc.on('exit', handleExit)
+  TrackUtilityProcess.trackUtilityProcess(rawIpc, name)
 }

--- a/packages/main-process/src/parts/LaunchSharedProcess/LaunchSharedProcess.ts
+++ b/packages/main-process/src/parts/LaunchSharedProcess/LaunchSharedProcess.ts
@@ -1,5 +1,6 @@
-import { ElectronMessagePortRpcClient, ElectronUtilityProcessRpcParent } from '@lvce-editor/rpc'
+import { ElectronMessagePortRpcClient } from '@lvce-editor/rpc'
 import * as CommandMapRef from '../CommandMapRef/CommandMapRef.ts'
+import * as CreateElectronUtilityProcessRpc from '../CreateElectronUtilityProcessRpc/CreateElectronUtilityProcessRpc.ts'
 import * as ExitCode from '../ExitCode/ExitCode.ts'
 import * as GetPortTuple from '../GetPortTuple/GetPortTuple.ts'
 import * as GetSharedProcessArgv from '../GetSharedProcessArgv/GetSharedProcessArgv.ts'
@@ -32,7 +33,7 @@ export const launchSharedProcess = async ({ env = {}, method }) => {
     ...process.env,
     ...env,
   }
-  const sharedProcessRpc = await ElectronUtilityProcessRpcParent.create({
+  const sharedProcessRpc = await CreateElectronUtilityProcessRpc.createElectronUtilityProcessRpc({
     argv: [],
     commandMap: CommandMapRef.commandMapRef,
     env: fullEnv,

--- a/packages/main-process/src/parts/TrackUtilityProcess/TrackUtilityProcess.ts
+++ b/packages/main-process/src/parts/TrackUtilityProcess/TrackUtilityProcess.ts
@@ -1,0 +1,19 @@
+import * as FormatUtilityProcessName from '../FormatUtilityProcessName/FormatUtilityProcessName.ts'
+import * as UtilityProcessState from '../UtilityProcessState/UtilityProcessState.ts'
+
+export const trackUtilityProcess = (rawIpc: any, name: string): void => {
+  if (!rawIpc?.pid) {
+    return
+  }
+  const { pid } = rawIpc
+  const formattedName = FormatUtilityProcessName.formatUtilityProcessName(name)
+  UtilityProcessState.add(pid, rawIpc, formattedName)
+  const cleanup = (): void => {
+    UtilityProcessState.remove(pid)
+    rawIpc.off('exit', handleExit)
+  }
+  const handleExit = (): void => {
+    cleanup()
+  }
+  rawIpc.on('exit', handleExit)
+}

--- a/packages/main-process/test/CreateElectronUtilityProcessRpc.test.ts
+++ b/packages/main-process/test/CreateElectronUtilityProcessRpc.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const mockCreate = jest.fn()
+
+jest.unstable_mockModule('@lvce-editor/rpc', () => ({
+  ElectronUtilityProcessRpcParent: {
+    create: mockCreate,
+  },
+}))
+
+const CreateElectronUtilityProcessRpc = await import('../src/parts/CreateElectronUtilityProcessRpc/CreateElectronUtilityProcessRpc.ts')
+const UtilityProcessState = await import('../src/parts/UtilityProcessState/UtilityProcessState.ts')
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  UtilityProcessState.state.all = Object.create(null)
+})
+
+test('createElectronUtilityProcessRpc - tracks utility process until exit', async () => {
+  let handleExit: (() => void) | undefined
+  const rawIpc = {
+    off: jest.fn(),
+    on: jest.fn((event: string, listener: () => void) => {
+      if (event === 'exit') {
+        handleExit = listener
+      }
+    }),
+    pid: 123,
+  }
+  const rpc = {
+    ipc: {
+      _rawIpc: rawIpc,
+    },
+  }
+  mockCreate.mockImplementation(async () => rpc)
+
+  const result = await CreateElectronUtilityProcessRpc.createElectronUtilityProcessRpc({
+    name: 'File System Process',
+  })
+
+  expect(result).toBe(rpc)
+  expect(UtilityProcessState.getAll()).toEqual([
+    [
+      '123',
+      {
+        name: 'file-system-process',
+        process: rawIpc,
+      },
+    ],
+  ])
+
+  handleExit?.()
+
+  expect(UtilityProcessState.getAll()).toEqual([])
+  expect(rawIpc.off).toHaveBeenCalledWith('exit', handleExit)
+})
+
+test('createElectronUtilityProcessRpc - ignores rpc without process id', async () => {
+  const rpc = {
+    ipc: {
+      _rawIpc: {},
+    },
+  }
+  mockCreate.mockImplementation(async () => rpc)
+
+  await CreateElectronUtilityProcessRpc.createElectronUtilityProcessRpc({
+    name: 'File System Process',
+  })
+
+  expect(UtilityProcessState.getAll()).toEqual([])
+})

--- a/packages/main-process/test/CreatePidMap.test.ts
+++ b/packages/main-process/test/CreatePidMap.test.ts
@@ -17,7 +17,12 @@ jest.unstable_mockModule('electron', () => {
 })
 
 const CreatePidMap = await import('../src/parts/CreatePidMap/CreatePidMap.ts')
+const UtilityProcessState = await import('../src/parts/UtilityProcessState/UtilityProcessState.ts')
 const electron = await import('electron')
+
+beforeEach(() => {
+  UtilityProcessState.state.all = Object.create(null)
+})
 
 test('createPidMap - detect chrome devtools', () => {
   // @ts-expect-error
@@ -70,4 +75,14 @@ test('createPidMap - unknown renderer', () => {
     return []
   })
   expect(CreatePidMap.createPidMap()).toEqual({})
+})
+
+test('createPidMap - utility process', () => {
+  // @ts-expect-error
+  electron.BrowserWindow.getAllWindows.mockReturnValue([])
+  UtilityProcessState.add(123, {}, 'file-system-process')
+
+  expect(CreatePidMap.createPidMap()).toEqual({
+    123: 'file-system-process',
+  })
 })


### PR DESCRIPTION
Restores main-process lifecycle tracking for Electron utility processes created through the RPC launcher. Process Explorer can now resolve shared and utility process PIDs to their friendly launch names, with stale entries removed when processes exit.