### PR TITLE
feature: take web worker heap snapshots

### DIFF
--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -50,6 +50,7 @@ export const commandMap = {
   'ElectronContextMenu.openContextMenu': ElectronContextMenu.openContextMenu,
   'ElectronDeveloper.crashMainProcess': ElectronDeveloper.crashMainProcess,
   'ElectronDeveloper.getPerformanceEntries': ElectronDeveloper.getPerformanceEntries,
+  'ElectronDeveloper.takeWorkerHeapSnapshot': ElectronDeveloper.takeWorkerHeapSnapshot,
   'ElectronDialog.showMessageBox': ElectronDialog.showMessageBox,
   'ElectronDialog.showOpenDialog': ElectronDialog.showOpenDialog,
   'ElectronDialog.showSaveDialog': ElectronDialog.showSaveDialog,

--- a/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ipc.ts
+++ b/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ipc.ts
@@ -5,4 +5,5 @@ export const name = 'ElectronDeveloper'
 export const Commands = {
   crashMainProcess: Developer.crashMainProcess,
   getPerformanceEntries: Developer.getPerformanceEntries,
+  takeWorkerHeapSnapshot: Developer.takeWorkerHeapSnapshot,
 }

--- a/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ts
+++ b/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ts
@@ -1,4 +1,5 @@
 import * as Performance from '../Performance/Performance.ts'
+export { takeWorkerHeapSnapshot } from '../TakeWorkerHeapSnapshot/TakeWorkerHeapSnapshot.ts'
 
 export const getPerformanceEntries = (): any => {
   const entries = Performance.getEntries()

--- a/packages/main-process/src/parts/TakeWorkerHeapSnapshot/TakeWorkerHeapSnapshot.ts
+++ b/packages/main-process/src/parts/TakeWorkerHeapSnapshot/TakeWorkerHeapSnapshot.ts
@@ -1,0 +1,108 @@
+import * as Electron from 'electron'
+import { closeSync, mkdirSync, openSync, rmSync, writeSync } from 'node:fs'
+import { join } from 'node:path'
+import * as Assert from '../Assert/Assert.ts'
+
+interface TargetInfo {
+  readonly parentFrameId?: string
+  readonly targetId: string
+  readonly title: string
+  readonly type: string
+}
+
+interface TargetInfosResult {
+  readonly targetInfos: readonly TargetInfo[]
+}
+
+interface FrameTreeResult {
+  readonly frameTree: {
+    readonly frame: {
+      readonly id: string
+    }
+  }
+}
+
+const getFileName = (workerName: string): string => {
+  const safeWorkerName = workerName.replaceAll(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-/, '').replace(/-$/, '') || 'worker'
+  return `${safeWorkerName}-${Date.now()}.heapsnapshot`
+}
+
+export const takeWorkerHeapSnapshot = async (windowId: number, workerName: string): Promise<string> => {
+  Assert.number(windowId)
+  Assert.string(workerName)
+  const browserWindow = Electron.BrowserWindow.fromId(windowId)
+  if (!browserWindow) {
+    throw new Error(`Browser window not found: ${windowId}`)
+  }
+  const electronDebugger = browserWindow.webContents.debugger
+  const wasAttached = electronDebugger.isAttached()
+  let fileDescriptor: number | undefined
+  let filePath = ''
+  let sessionId = ''
+  let success = false
+  if (!wasAttached) {
+    electronDebugger.attach()
+  }
+  try {
+    const { frameTree } = (await electronDebugger.sendCommand('Page.getFrameTree')) as FrameTreeResult
+    const { targetInfos } = (await electronDebugger.sendCommand('Target.getTargets')) as TargetInfosResult
+    const target = targetInfos.find(
+      (targetInfo) => targetInfo.type === 'worker' && targetInfo.title === workerName && targetInfo.parentFrameId === frameTree.frame.id,
+    )
+    if (!target) {
+      throw new Error(`Worker not found: ${workerName}`)
+    }
+    const attachResult = await electronDebugger.sendCommand('Target.attachToTarget', {
+      flatten: true,
+      targetId: target.targetId,
+    })
+    sessionId = attachResult.sessionId
+    const downloadsPath = Electron.app.getPath('downloads')
+    mkdirSync(downloadsPath, { recursive: true })
+    filePath = join(downloadsPath, getFileName(workerName))
+    fileDescriptor = openSync(filePath, 'wx')
+    const currentFileDescriptor = fileDescriptor
+    let writeError: Error | undefined
+    const handleMessage = (_event: unknown, method: string, parameters: any, messageSessionId: string): void => {
+      if (method !== 'HeapProfiler.addHeapSnapshotChunk' || messageSessionId !== sessionId || writeError) {
+        return
+      }
+      try {
+        writeSync(currentFileDescriptor, parameters.chunk)
+      } catch (error) {
+        writeError = error as Error
+      }
+    }
+    electronDebugger.on('message', handleMessage)
+    try {
+      await electronDebugger.sendCommand('HeapProfiler.enable', undefined, sessionId)
+      await electronDebugger.sendCommand('HeapProfiler.takeHeapSnapshot', { reportProgress: false }, sessionId)
+      if (writeError) {
+        throw writeError
+      }
+    } finally {
+      electronDebugger.off('message', handleMessage)
+    }
+    success = true
+    return filePath
+  } finally {
+    try {
+      if (fileDescriptor !== undefined) {
+        closeSync(fileDescriptor)
+      }
+      if (!success && filePath) {
+        rmSync(filePath, { force: true })
+      }
+    } finally {
+      try {
+        if (sessionId && electronDebugger.isAttached()) {
+          await electronDebugger.sendCommand('Target.detachFromTarget', { sessionId })
+        }
+      } finally {
+        if (!wasAttached && electronDebugger.isAttached()) {
+          electronDebugger.detach()
+        }
+      }
+    }
+  }
+}

--- a/packages/main-process/test/TakeWorkerHeapSnapshot.test.ts
+++ b/packages/main-process/test/TakeWorkerHeapSnapshot.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import { EventEmitter } from 'node:events'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+let attached = false
+let downloadsPath = ''
+let mockWindow: any
+let takeSnapshotError: Error | undefined
+
+const emitter = new EventEmitter()
+const electronDebugger = {
+  attach: jest.fn(() => {
+    attached = true
+  }),
+  detach: jest.fn(() => {
+    attached = false
+  }),
+  isAttached: jest.fn(() => attached),
+  off: jest.fn((event: string, listener: (...args: readonly any[]) => void) => {
+    emitter.off(event, listener)
+  }),
+  on: jest.fn((event: string, listener: (...args: readonly any[]) => void) => {
+    emitter.on(event, listener)
+  }),
+  sendCommand: jest.fn(async (method: string, _parameters?: any, sessionId?: string) => {
+    switch (method) {
+      case 'HeapProfiler.enable':
+        return {}
+      case 'HeapProfiler.takeHeapSnapshot':
+        emitter.emit('message', {}, 'Runtime.consoleAPICalled', {}, sessionId)
+        emitter.emit('message', {}, 'HeapProfiler.addHeapSnapshotChunk', { chunk: 'ignored' }, 'other-session')
+        emitter.emit('message', {}, 'HeapProfiler.addHeapSnapshotChunk', { chunk: '{"snapshot":' }, sessionId)
+        emitter.emit('message', {}, 'HeapProfiler.addHeapSnapshotChunk', { chunk: '{}}' }, sessionId)
+        if (takeSnapshotError) {
+          throw takeSnapshotError
+        }
+        return {}
+      case 'Page.getFrameTree':
+        return { frameTree: { frame: { id: 'main-frame' } } }
+      case 'Target.attachToTarget':
+        return { sessionId: 'worker-session' }
+      case 'Target.detachFromTarget':
+        return {}
+      case 'Target.getTargets':
+        return {
+          targetInfos: [
+            { targetId: 'page-target', title: 'Lvce Editor', type: 'page' },
+            {
+              parentFrameId: 'other-frame',
+              targetId: 'other-worker-target',
+              title: 'Extension API (Electron): sample.extension',
+              type: 'worker',
+            },
+            {
+              parentFrameId: 'main-frame',
+              targetId: 'worker-target',
+              title: 'Extension API (Electron): sample.extension',
+              type: 'worker',
+            },
+          ],
+        }
+      default:
+        throw new Error(`Unexpected command: ${method}`)
+    }
+  }),
+}
+
+jest.unstable_mockModule('electron', () => ({
+  app: {
+    getPath: jest.fn(() => downloadsPath),
+  },
+  BrowserWindow: {
+    fromId: jest.fn(() => mockWindow),
+  },
+}))
+
+const { takeWorkerHeapSnapshot } = await import('../src/parts/TakeWorkerHeapSnapshot/TakeWorkerHeapSnapshot.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  emitter.removeAllListeners()
+  attached = false
+  takeSnapshotError = undefined
+  downloadsPath = mkdtempSync(join(tmpdir(), 'lvce-worker-heap-snapshot-'))
+  mockWindow = {
+    webContents: {
+      debugger: electronDebugger,
+    },
+  }
+})
+
+afterEach(() => {
+  rmSync(downloadsPath, { force: true, recursive: true })
+})
+
+test('takes a heap snapshot for the named worker', async () => {
+  jest.spyOn(Date, 'now').mockReturnValue(123_456)
+
+  const result = await takeWorkerHeapSnapshot(7, 'Extension API (Electron): sample.extension')
+
+  expect(result).toBe(join(downloadsPath, 'Extension-API-Electron-sample.extension-123456.heapsnapshot'))
+  expect(readFileSync(result, 'utf8')).toBe('{"snapshot":{}}')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(1, 'Page.getFrameTree')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(2, 'Target.getTargets')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(3, 'Target.attachToTarget', {
+    flatten: true,
+    targetId: 'worker-target',
+  })
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(4, 'HeapProfiler.enable', undefined, 'worker-session')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(
+    5,
+    'HeapProfiler.takeHeapSnapshot',
+    { reportProgress: false },
+    'worker-session',
+  )
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(6, 'Target.detachFromTarget', { sessionId: 'worker-session' })
+  expect(electronDebugger.attach).toHaveBeenCalledTimes(1)
+  expect(electronDebugger.detach).toHaveBeenCalledTimes(1)
+})
+
+test('reuses an attached debugger', async () => {
+  attached = true
+
+  await takeWorkerHeapSnapshot(7, 'Extension API (Electron): sample.extension')
+
+  expect(electronDebugger.attach).not.toHaveBeenCalled()
+  expect(electronDebugger.detach).not.toHaveBeenCalled()
+})
+
+test('throws when the browser window does not exist', async () => {
+  mockWindow = undefined
+
+  await expect(takeWorkerHeapSnapshot(7, 'Extension API (Electron): sample.extension')).rejects.toThrow('Browser window not found: 7')
+  expect(electronDebugger.attach).not.toHaveBeenCalled()
+})
+
+test('throws when the worker does not exist', async () => {
+  electronDebugger.sendCommand.mockResolvedValueOnce({ frameTree: { frame: { id: 'main-frame' } } }).mockResolvedValueOnce({ targetInfos: [] })
+
+  await expect(takeWorkerHeapSnapshot(7, 'Extension API (Electron): missing.extension')).rejects.toThrow(
+    'Worker not found: Extension API (Electron): missing.extension',
+  )
+  expect(electronDebugger.detach).toHaveBeenCalledTimes(1)
+})
+
+test('removes an incomplete snapshot', async () => {
+  takeSnapshotError = new Error('Snapshot failed')
+
+  await expect(takeWorkerHeapSnapshot(7, 'Extension API (Electron): sample.extension')).rejects.toThrow('Snapshot failed')
+  expect(readdirSync(downloadsPath)).toEqual([])
+})


### PR DESCRIPTION
Adds a main-process API that targets a named worker in a specific Electron window and saves its heap snapshot to the Downloads folder.