### PR TITLE
fix: show overlays above simple browser

### DIFF
--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -81,6 +81,9 @@ export const commandMap = {
   'ElectronWebContentsViewFunctions.cancelNavigation': ElectronWebContentsViewFunctions.wrapBrowserViewCommand(
     ElectronWebContentsViewFunctions.cancelNavigation,
   ),
+  'ElectronWebContentsViewFunctions.capturePage': ElectronWebContentsViewFunctions.wrapBrowserViewCommand(
+    ElectronWebContentsViewFunctions.capturePage,
+  ),
   'ElectronWebContentsViewFunctions.copyImageAt': ElectronWebContentsViewFunctions.wrapBrowserViewCommand(
     ElectronWebContentsViewFunctions.copyImageAt,
   ),

--- a/packages/main-process/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.ipc.ts
+++ b/packages/main-process/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.ipc.ts
@@ -6,6 +6,7 @@ export const Commands = {
   addToWindow: ElectronWebContentsViewFunctions.addToWindow,
   backward: ElectronWebContentsViewFunctions.wrapBrowserViewCommand(ElectronWebContentsViewFunctions.backward),
   cancelNavigation: ElectronWebContentsViewFunctions.wrapBrowserViewCommand(ElectronWebContentsViewFunctions.cancelNavigation),
+  capturePage: ElectronWebContentsViewFunctions.wrapBrowserViewCommand(ElectronWebContentsViewFunctions.capturePage),
   copyImageAt: ElectronWebContentsViewFunctions.wrapBrowserViewCommand(ElectronWebContentsViewFunctions.copyImageAt),
   executeJavaScript: ElectronWebContentsViewFunctions.wrapBrowserViewCommand(ElectronWebContentsViewFunctions.executeJavaScript),
   focus: ElectronWebContentsViewFunctions.wrapBrowserViewCommand(ElectronWebContentsViewFunctions.focus),

--- a/packages/main-process/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.ts
+++ b/packages/main-process/src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.ts
@@ -95,6 +95,11 @@ export const getDomTree = async (view: WebContentsView) => {
   return getSlimCode(result)
 }
 
+export const capturePage = async (view: WebContentsView): Promise<string> => {
+  const image = await view.webContents.capturePage()
+  return image.toDataURL()
+}
+
 export const getConsolLogs = async (view: WebContentsView) => {
   const result = await getBodyOuterHtml(view)
   return getSlimCode(result)

--- a/packages/main-process/test/ElectronWebContentsViewFunctions.test.ts
+++ b/packages/main-process/test/ElectronWebContentsViewFunctions.test.ts
@@ -1,0 +1,22 @@
+import { expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('electron', () => ({
+  BrowserWindow: {},
+}))
+
+const ElectronWebContentsViewFunctions = await import('../src/parts/ElectronWebContentsViewFunctions/ElectronWebContentsViewFunctions.ts')
+
+test('capturePage returns a data url', async () => {
+  const toDataURL = jest.fn(() => 'data:image/png;base64,c25hcHNob3Q=')
+  const capturePage = jest.fn(async () => ({ toDataURL }))
+  const view = {
+    webContents: {
+      capturePage,
+    },
+  }
+
+  // @ts-expect-error minimal WebContentsView mock
+  await expect(ElectronWebContentsViewFunctions.capturePage(view)).resolves.toBe('data:image/png;base64,c25hcHNob3Q=')
+  expect(capturePage).toHaveBeenCalledTimes(1)
+  expect(toDataURL).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Support capturing a WebContentsView page as a PNG data URL so native content can be replaced while editor overlays are visible.