### PR TITLE
feature: support native fullscreen toggling

### DIFF
--- a/packages/main-process/src/parts/ElectronWindow/ElectronWindow.ts
+++ b/packages/main-process/src/parts/ElectronWindow/ElectronWindow.ts
@@ -78,6 +78,10 @@ const toggleDevtools = (browserWindow) => {
   browserWindow.webContents.openDevTools(devtoolsOptions)
 }
 
+const toggleFullScreen = (browserWindow: Electron.BrowserWindow) => {
+  browserWindow.setFullScreen(!browserWindow.isFullScreen())
+}
+
 export const executeWindowFunction = (browserWindowId, key) => {
   const browserWindow = getBrowserWindow(browserWindowId)
   if (!browserWindow) {
@@ -85,6 +89,10 @@ export const executeWindowFunction = (browserWindowId, key) => {
   }
   if (key === 'toggleDevtools') {
     toggleDevtools(browserWindow)
+    return
+  }
+  if (key === 'toggleFullScreen') {
+    toggleFullScreen(browserWindow)
     return
   }
   browserWindow[key]()

--- a/packages/main-process/test/ElectronWindow.test.ts
+++ b/packages/main-process/test/ElectronWindow.test.ts
@@ -37,6 +37,38 @@ test('executeWindowFunction - toggleDevtools - no window', () => {
   expect(ElectronWindow.executeWindowFunction(1, 'toggleDevtools')).toBeUndefined()
 })
 
+test('executeWindowFunction - toggleFullScreen - enters full screen', () => {
+  const isFullScreen = jest.fn(() => false)
+  const setFullScreen = jest.fn()
+  mockWindow = {
+    id: 1,
+    isFullScreen,
+    setFullScreen,
+  }
+
+  ElectronWindow.executeWindowFunction(1, 'toggleFullScreen')
+
+  expect(isFullScreen).toHaveBeenCalledTimes(1)
+  expect(setFullScreen).toHaveBeenCalledTimes(1)
+  expect(setFullScreen).toHaveBeenCalledWith(true)
+})
+
+test('executeWindowFunction - toggleFullScreen - exits full screen', () => {
+  const isFullScreen = jest.fn(() => true)
+  const setFullScreen = jest.fn()
+  mockWindow = {
+    id: 1,
+    isFullScreen,
+    setFullScreen,
+  }
+
+  ElectronWindow.executeWindowFunction(1, 'toggleFullScreen')
+
+  expect(isFullScreen).toHaveBeenCalledTimes(1)
+  expect(setFullScreen).toHaveBeenCalledTimes(1)
+  expect(setFullScreen).toHaveBeenCalledWith(false)
+})
+
 test('executeWindowFunction - toggleDevtools - closes when already open', () => {
   const pageWebContents = {
     closeDevTools: jest.fn(),


### PR DESCRIPTION
Adds native Electron window fullscreen toggling so renderer commands can enter and exit fullscreen without relying on transient browser user activation.