### PR TITLE
fix: avoid duplicate GitHub CORS headers

### DIFF
--- a/packages/main-process/src/parts/CreateElectronSession/CreateElectronSession.ts
+++ b/packages/main-process/src/parts/CreateElectronSession/CreateElectronSession.ts
@@ -1,4 +1,5 @@
 import * as Electron from 'electron'
+import * as GetCorsResponseHeaders from '../GetCorsResponseHeaders/GetCorsResponseHeaders.ts'
 import * as HandlePermission from '../HandlePermission/HandlePermission.ts'
 import * as HandleRequest from '../HandleRequest/HandleRequest.ts'
 import * as IsSessionCacheEnabled from '../IsSessionCacheEnabled/IsSessionCacheEnabled.ts'
@@ -10,10 +11,7 @@ const onHeadersReceivedCallback = (
   callback: (headersReceivedResponse: globalThis.Electron.HeadersReceivedResponse) => void,
 ) => {
   callback({
-    responseHeaders: {
-      'Access-Control-Allow-Origin': ['*'],
-      ...details.responseHeaders,
-    },
+    responseHeaders: GetCorsResponseHeaders.getCorsResponseHeaders(details.responseHeaders),
   })
 }
 

--- a/packages/main-process/src/parts/GetCorsResponseHeaders/GetCorsResponseHeaders.ts
+++ b/packages/main-process/src/parts/GetCorsResponseHeaders/GetCorsResponseHeaders.ts
@@ -1,0 +1,12 @@
+const accessControlAllowOrigin = 'access-control-allow-origin'
+
+export const getCorsResponseHeaders = (responseHeaders: Record<string, string[]> = {}): Record<string, string[]> => {
+  const hasAccessControlAllowOrigin = Object.keys(responseHeaders).some((key) => key.toLowerCase() === accessControlAllowOrigin)
+  if (hasAccessControlAllowOrigin) {
+    return responseHeaders
+  }
+  return {
+    ...responseHeaders,
+    'Access-Control-Allow-Origin': ['*'],
+  }
+}

--- a/packages/main-process/test/GetCorsResponseHeaders.test.ts
+++ b/packages/main-process/test/GetCorsResponseHeaders.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@jest/globals'
+import * as GetCorsResponseHeaders from '../src/parts/GetCorsResponseHeaders/GetCorsResponseHeaders.ts'
+
+test('getCorsResponseHeaders - adds access control allow origin header', () => {
+  expect(
+    GetCorsResponseHeaders.getCorsResponseHeaders({
+      'Content-Type': ['application/octet-stream'],
+    }),
+  ).toEqual({
+    'Access-Control-Allow-Origin': ['*'],
+    'Content-Type': ['application/octet-stream'],
+  })
+})
+
+test('getCorsResponseHeaders - preserves existing access control allow origin header case-insensitively', () => {
+  expect(
+    GetCorsResponseHeaders.getCorsResponseHeaders({
+      'access-control-allow-origin': ['*'],
+      'Content-Type': ['application/json'],
+    }),
+  ).toEqual({
+    'access-control-allow-origin': ['*'],
+    'Content-Type': ['application/json'],
+  })
+})
+
+test('getCorsResponseHeaders - supports missing response headers', () => {
+  expect(GetCorsResponseHeaders.getCorsResponseHeaders()).toEqual({
+    'Access-Control-Allow-Origin': ['*'],
+  })
+})


### PR DESCRIPTION
Preserve existing GitHub CORS response headers case-insensitively, while still adding a wildcard header for release downloads that do not provide one. This prevents Electron changelog requests from producing an invalid duplicate origin value.