### PR TITLE
fix: expose main process id

### DIFF
--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -31,6 +31,7 @@ import * as HandleElectronMessagePort from '../HandleElectronMessagePort/HandleE
 import * as IpcParent from '../IpcParent/IpcParent.ts'
 import * as OpenExternal from '../OpenExternal/OpenExternal.ts'
 import * as Process from '../Process/Process.ts'
+import * as ProcessId from '../ProcessId/ProcessId.ts'
 import * as TemporaryMessagePort from '../TemporaryMessagePort/TemporaryMessagePort.ts'
 import * as Trash from '../Trash/Trash.ts'
 
@@ -143,6 +144,7 @@ export const commandMap = {
   'Process.getV8Version': Process.getV8Version,
   'Process.writeStderr': Process.writeStderr,
   'Process.writeStdout': Process.writeStdout,
+  'ProcessId.getMainProcessId': ProcessId.getMainProcessId,
   'TemporaryMessagePort.createPortTuple': TemporaryMessagePort.createPortTuple,
   'TemporaryMessagePort.dispose': TemporaryMessagePort.dispose,
   'TemporaryMessagePort.sendTo': TemporaryMessagePort.sendTo,

--- a/packages/main-process/src/parts/ProcessId/ProcessId.ipc.ts
+++ b/packages/main-process/src/parts/ProcessId/ProcessId.ipc.ts
@@ -1,0 +1,7 @@
+import * as ProcessId from './ProcessId.ts'
+
+export const name = 'ProcessId'
+
+export const Commands = {
+  getMainProcessId: ProcessId.getMainProcessId,
+}

--- a/packages/main-process/src/parts/ProcessId/ProcessId.ts
+++ b/packages/main-process/src/parts/ProcessId/ProcessId.ts
@@ -1,0 +1,3 @@
+export const getMainProcessId = (): number => {
+  return process.pid
+}

--- a/packages/main-process/test/ProcessId.test.ts
+++ b/packages/main-process/test/ProcessId.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
-import * as ProcessId from '../src/parts/ProcessId/ProcessId.ts'
 import * as ProcessIdIpc from '../src/parts/ProcessId/ProcessId.ipc.ts'
+import * as ProcessId from '../src/parts/ProcessId/ProcessId.ts'
 
 test('getMainProcessId returns the main process id', () => {
   expect(ProcessId.getMainProcessId()).toBe(process.pid)

--- a/packages/main-process/test/ProcessId.test.ts
+++ b/packages/main-process/test/ProcessId.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@jest/globals'
+import * as ProcessId from '../src/parts/ProcessId/ProcessId.ts'
+import * as ProcessIdIpc from '../src/parts/ProcessId/ProcessId.ipc.ts'
+
+test('getMainProcessId returns the main process id', () => {
+  expect(ProcessId.getMainProcessId()).toBe(process.pid)
+})
+
+test('ipc exposes getMainProcessId', () => {
+  expect(ProcessIdIpc.name).toBe('ProcessId')
+  expect(ProcessIdIpc.Commands.getMainProcessId()).toBe(process.pid)
+})


### PR DESCRIPTION
Expose the Electron main process PID through the ProcessId.getMainProcessId command used by Process Explorer. This restores Electron process loading after Process Explorer moved to a direct main-process RPC.