### PR TITLE
feature: add window output logging

### DIFF
--- a/packages/main-process/src/parts/AppWindow/AppWindow.ts
+++ b/packages/main-process/src/parts/AppWindow/AppWindow.ts
@@ -10,6 +10,7 @@ import * as Logger from '../Logger/Logger.ts'
 import * as Performance from '../Performance/Performance.ts'
 import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMarkerType.ts'
 import { VError } from '../VError/VError.ts'
+import * as WindowLogger from '../WindowLogger/WindowLogger.ts'
 import { WindowLoadError } from '../WindowLoadError/WindowLoadError.ts'
 // TODO impossible to test these methods
 // and ensure that there is no memory leak
@@ -32,9 +33,6 @@ const addDevDiagnostics = (window) => {
   if (!process.env.DEV) {
     return
   }
-  window.webContents.on('console-message', (_event, level, message, line, sourceId) => {
-    Logger.info(`[app window console] level=${level} source=${sourceId}:${line} message=${message}`)
-  })
   window.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedUrl, isMainFrame) => {
     Logger.error(`[app window did-fail-load] code=${errorCode} mainFrame=${isMainFrame} url=${validatedUrl} error=${errorDescription}`)
   })
@@ -58,6 +56,7 @@ export const createAppWindow = async (windowOptions, parsedArgs, workingDirector
     },
   })
   Performance.mark(PerformanceMarkerType.DidCreateCodeWindow)
+  WindowLogger.addListener(window.webContents)
   addDevDiagnostics(window)
 
   const handleReadyToShow = () => {

--- a/packages/main-process/src/parts/AppWindow/AppWindow.ts
+++ b/packages/main-process/src/parts/AppWindow/AppWindow.ts
@@ -10,8 +10,8 @@ import * as Logger from '../Logger/Logger.ts'
 import * as Performance from '../Performance/Performance.ts'
 import * as PerformanceMarkerType from '../PerformanceMarkerType/PerformanceMarkerType.ts'
 import { VError } from '../VError/VError.ts'
-import * as WindowLogger from '../WindowLogger/WindowLogger.ts'
 import { WindowLoadError } from '../WindowLoadError/WindowLoadError.ts'
+import * as WindowLogger from '../WindowLogger/WindowLogger.ts'
 // TODO impossible to test these methods
 // and ensure that there is no memory leak
 

--- a/packages/main-process/src/parts/CreateFileLogger/CreateFileLogger.ts
+++ b/packages/main-process/src/parts/CreateFileLogger/CreateFileLogger.ts
@@ -1,0 +1,13 @@
+import { Console } from 'node:console'
+import { createWriteStream, mkdirSync } from 'node:fs'
+import * as Path from '../Path/Path.ts'
+import * as Platform from '../Platform/Platform.ts'
+
+export const createFileLogger = (fileName: string): Console => {
+  mkdirSync(Platform.logsDir, {
+    recursive: true,
+  })
+  const logFile = Path.join(Platform.logsDir, fileName)
+  const writeStream = createWriteStream(logFile)
+  return new Console(writeStream)
+}

--- a/packages/main-process/src/parts/Logger/Logger.ts
+++ b/packages/main-process/src/parts/Logger/Logger.ts
@@ -1,6 +1,4 @@
-import { Console } from 'node:console'
-import { createWriteStream } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { createFileLogger } from '../CreateFileLogger/CreateFileLogger.ts'
 
 // TODO disable logging via environment variable, don't enable logging during tests
 
@@ -13,10 +11,7 @@ const state: State = {
 }
 
 const createConsole = (): Console => {
-  const logFile = `${tmpdir()}/log-main-process.txt`
-  const writeStream = createWriteStream(logFile)
-  const logger = new Console(writeStream)
-  return logger
+  return createFileLogger('log-main-process.txt')
 }
 
 const getOrCreateLogger = (): Console => {

--- a/packages/main-process/src/parts/Platform/Platform.ts
+++ b/packages/main-process/src/parts/Platform/Platform.ts
@@ -18,6 +18,10 @@ const xdgData = env.XDG_DATA_HOME || (homeDirectory ? Path.join(homeDirectory, '
 
 const dataDir = Path.join(xdgData || tmpdir(), applicationName)
 
+const xdgState = env.XDG_STATE_HOME || (homeDirectory ? Path.join(homeDirectory, '.local', 'state') : undefined)
+
+export const logsDir = Path.join(xdgState || tmpdir(), applicationName, 'logs')
+
 export const getBuiltinSelfTestPath = () => {
   return process.env.BUILTIN_SELF_TEST_PATH || Path.join(Root.root, 'extensions', 'builtin.self-test', 'bin', 'SelfTest.ts')
 }

--- a/packages/main-process/src/parts/WindowLogger/WindowLogger.ts
+++ b/packages/main-process/src/parts/WindowLogger/WindowLogger.ts
@@ -1,0 +1,26 @@
+import type { WebContents, WebContentsConsoleMessageEventParams } from 'electron'
+import { createFileLogger } from '../CreateFileLogger/CreateFileLogger.ts'
+
+interface State {
+  console: Console | undefined
+}
+
+const state: State = {
+  console: undefined,
+}
+
+const getOrCreateLogger = (): Console => {
+  state.console ||= createFileLogger('log-window.txt')
+  return state.console
+}
+
+export const formatMessage = ({ level, lineNumber, message, sourceId }: WebContentsConsoleMessageEventParams): string => {
+  const source = sourceId ? ` (${sourceId}:${lineNumber})` : ''
+  return `${new Date().toISOString()} [${level}] [Window] ${message}${source}`
+}
+
+export const addListener = (webContents: WebContents, logger: Pick<Console, 'log'> = getOrCreateLogger()): void => {
+  webContents.on('console-message', (event) => {
+    logger.log(formatMessage(event))
+  })
+}

--- a/packages/main-process/test/WindowLogger.test.ts
+++ b/packages/main-process/test/WindowLogger.test.ts
@@ -1,0 +1,54 @@
+import { expect, jest, test } from '@jest/globals'
+import { addListener, formatMessage } from '../src/parts/WindowLogger/WindowLogger.ts'
+
+test('formatMessage', () => {
+  const message = formatMessage({
+    frame: undefined as any,
+    level: 'error',
+    lineNumber: 42,
+    message: 'Something went wrong',
+    sourceId: 'file:///app/renderer.js',
+  })
+
+  expect(message).toMatch(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[error\] \[Window\] Something went wrong \(file:\/\/\/app\/renderer\.js:42\)$/,
+  )
+})
+
+test('formatMessage - no source', () => {
+  const message = formatMessage({
+    frame: undefined as any,
+    level: 'info',
+    lineNumber: 0,
+    message: 'Ready',
+    sourceId: '',
+  })
+
+  expect(message).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[info\] \[Window\] Ready$/)
+})
+
+test('addListener', () => {
+  const listeners: Record<string, (event: any) => void> = Object.create(null)
+  const webContents = {
+    on: jest.fn((event: string, listener: (event: any) => void) => {
+      listeners[event] = listener
+    }),
+  }
+  const logger = {
+    log: jest.fn(),
+  }
+
+  addListener(webContents as any, logger)
+  listeners['console-message']({
+    frame: undefined,
+    level: 'warning',
+    lineNumber: 7,
+    message: 'Deprecated API',
+    sourceId: 'file:///app/api.js',
+  })
+
+  expect(webContents.on).toHaveBeenCalledWith('console-message', expect.any(Function))
+  expect(logger.log).toHaveBeenCalledWith(
+    expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[warning\] \[Window\] Deprecated API \(file:\/\/\/app\/api\.js:7\)$/),
+  )
+})


### PR DESCRIPTION
Adds a persistent Electron Window log backed by renderer console messages. Stores both main-process and window logs in the application logs directory exposed to the Output view.