### PR TITLE
feature: add extension cpu profiling

### DIFF
--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -51,6 +51,8 @@ export const commandMap = {
   'ElectronContextMenu.openContextMenu': ElectronContextMenu.openContextMenu,
   'ElectronDeveloper.crashMainProcess': ElectronDeveloper.crashMainProcess,
   'ElectronDeveloper.getPerformanceEntries': ElectronDeveloper.getPerformanceEntries,
+  'ElectronDeveloper.takeWindowCpuProfile': ElectronDeveloper.takeWindowCpuProfile,
+  'ElectronDeveloper.takeWorkerCpuProfile': ElectronDeveloper.takeWorkerCpuProfile,
   'ElectronDeveloper.takeWorkerHeapSnapshot': ElectronDeveloper.takeWorkerHeapSnapshot,
   'ElectronDialog.showMessageBox': ElectronDialog.showMessageBox,
   'ElectronDialog.showOpenDialog': ElectronDialog.showOpenDialog,

--- a/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ipc.ts
+++ b/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ipc.ts
@@ -5,5 +5,7 @@ export const name = 'ElectronDeveloper'
 export const Commands = {
   crashMainProcess: Developer.crashMainProcess,
   getPerformanceEntries: Developer.getPerformanceEntries,
+  takeWindowCpuProfile: Developer.takeWindowCpuProfile,
+  takeWorkerCpuProfile: Developer.takeWorkerCpuProfile,
   takeWorkerHeapSnapshot: Developer.takeWorkerHeapSnapshot,
 }

--- a/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ts
+++ b/packages/main-process/src/parts/ElectronDeveloper/ElectronDeveloper.ts
@@ -1,4 +1,5 @@
 import * as Performance from '../Performance/Performance.ts'
+export { takeWindowCpuProfile, takeWorkerCpuProfile } from '../TakeCpuProfile/TakeCpuProfile.ts'
 export { takeWorkerHeapSnapshot } from '../TakeWorkerHeapSnapshot/TakeWorkerHeapSnapshot.ts'
 
 export const getPerformanceEntries = (): any => {

--- a/packages/main-process/src/parts/TakeCpuProfile/TakeCpuProfile.ts
+++ b/packages/main-process/src/parts/TakeCpuProfile/TakeCpuProfile.ts
@@ -1,0 +1,124 @@
+import * as Electron from 'electron'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import * as Assert from '../Assert/Assert.ts'
+
+const profileDuration = 10_000
+
+interface TargetInfo {
+  readonly parentFrameId?: string
+  readonly targetId: string
+  readonly title: string
+  readonly type: string
+}
+
+interface TargetInfosResult {
+  readonly targetInfos: readonly TargetInfo[]
+}
+
+interface FrameTreeResult {
+  readonly frameTree: {
+    readonly frame: {
+      readonly id: string
+    }
+  }
+}
+
+interface ProfileResult {
+  readonly profile: unknown
+}
+
+const getFileName = (targetName: string): string => {
+  const safeTargetName =
+    targetName
+      .replaceAll(/[^a-zA-Z0-9._-]+/g, '-')
+      .replace(/^-/, '')
+      .replace(/-$/, '') || 'extension-host'
+  return `${safeTargetName}-${Date.now()}.cpuprofile`
+}
+
+const wait = async (): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, profileDuration)
+  })
+}
+
+const takeCpuProfile = async (windowId: number, workerName: string): Promise<string> => {
+  const browserWindow = Electron.BrowserWindow.fromId(windowId)
+  if (!browserWindow) {
+    throw new Error(`Browser window not found: ${windowId}`)
+  }
+  const electronDebugger = browserWindow.webContents.debugger
+  const wasAttached = electronDebugger.isAttached()
+  let filePath = ''
+  let profileStarted = false
+  let profileStopped = false
+  let sessionId: string | undefined
+  let success = false
+  if (!wasAttached) {
+    electronDebugger.attach()
+  }
+  try {
+    if (workerName) {
+      const { frameTree } = (await electronDebugger.sendCommand('Page.getFrameTree')) as FrameTreeResult
+      const { targetInfos } = (await electronDebugger.sendCommand('Target.getTargets')) as TargetInfosResult
+      const target = targetInfos.find(
+        (targetInfo) => targetInfo.type === 'worker' && targetInfo.title === workerName && targetInfo.parentFrameId === frameTree.frame.id,
+      )
+      if (!target) {
+        throw new Error(`Worker not found: ${workerName}`)
+      }
+      const attachResult = await electronDebugger.sendCommand('Target.attachToTarget', {
+        flatten: true,
+        targetId: target.targetId,
+      })
+      sessionId = attachResult.sessionId
+    }
+    await electronDebugger.sendCommand('Profiler.enable', undefined, sessionId)
+    await electronDebugger.sendCommand('Profiler.start', undefined, sessionId)
+    profileStarted = true
+    await wait()
+    const { profile } = (await electronDebugger.sendCommand('Profiler.stop', undefined, sessionId)) as ProfileResult
+    profileStopped = true
+    const downloadsPath = Electron.app.getPath('downloads')
+    mkdirSync(downloadsPath, { recursive: true })
+    const targetName = workerName || `Extension Host Window ${windowId}`
+    filePath = join(downloadsPath, getFileName(targetName))
+    writeFileSync(filePath, JSON.stringify(profile), { flag: 'wx' })
+    success = true
+    return filePath
+  } finally {
+    try {
+      if (profileStarted && !profileStopped && electronDebugger.isAttached()) {
+        await electronDebugger.sendCommand('Profiler.stop', undefined, sessionId)
+      }
+      if (electronDebugger.isAttached()) {
+        await electronDebugger.sendCommand('Profiler.disable', undefined, sessionId)
+      }
+    } finally {
+      try {
+        if (!success && filePath) {
+          rmSync(filePath, { force: true })
+        }
+        if (sessionId && electronDebugger.isAttached()) {
+          await electronDebugger.sendCommand('Target.detachFromTarget', { sessionId })
+        }
+      } finally {
+        if (!wasAttached && electronDebugger.isAttached()) {
+          electronDebugger.detach()
+        }
+      }
+    }
+  }
+}
+
+export const takeWindowCpuProfile = async (windowId: number): Promise<string> => {
+  Assert.number(windowId)
+  return takeCpuProfile(windowId, '')
+}
+
+export const takeWorkerCpuProfile = async (windowId: number, workerName: string): Promise<string> => {
+  Assert.number(windowId)
+  Assert.string(workerName)
+  return takeCpuProfile(windowId, workerName)
+}

--- a/packages/main-process/test/TakeCpuProfile.test.ts
+++ b/packages/main-process/test/TakeCpuProfile.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+let attached = false
+let downloadsPath = ''
+let mockWindow: any
+let stopError: Error | undefined
+
+const profile = {
+  endTime: 10_000,
+  nodes: [],
+  samples: [],
+  startTime: 0,
+  timeDeltas: [],
+}
+
+const electronDebugger = {
+  attach: jest.fn(() => {
+    attached = true
+  }),
+  detach: jest.fn(() => {
+    attached = false
+  }),
+  isAttached: jest.fn(() => attached),
+  sendCommand: jest.fn(async (method: string, _parameters?: unknown, _sessionId?: string) => {
+    switch (method) {
+      case 'Page.getFrameTree':
+        return { frameTree: { frame: { id: 'main-frame' } } }
+      case 'Profiler.disable':
+      case 'Profiler.enable':
+      case 'Profiler.start':
+      case 'Target.detachFromTarget':
+        return {}
+      case 'Profiler.stop':
+        if (stopError) {
+          throw stopError
+        }
+        return { profile }
+      case 'Target.attachToTarget':
+        return { sessionId: 'worker-session' }
+      case 'Target.getTargets':
+        return {
+          targetInfos: [
+            { targetId: 'page-target', title: 'Lvce Editor', type: 'page' },
+            {
+              parentFrameId: 'other-frame',
+              targetId: 'other-worker-target',
+              title: 'Extension API (Electron): sample.extension',
+              type: 'worker',
+            },
+            {
+              parentFrameId: 'main-frame',
+              targetId: 'worker-target',
+              title: 'Extension API (Electron): sample.extension',
+              type: 'worker',
+            },
+          ],
+        }
+      default:
+        throw new Error(`Unexpected command: ${method}`)
+    }
+  }),
+}
+
+jest.unstable_mockModule('electron', () => ({
+  app: {
+    getPath: jest.fn(() => downloadsPath),
+  },
+  BrowserWindow: {
+    fromId: jest.fn(() => mockWindow),
+  },
+}))
+
+const { takeWindowCpuProfile, takeWorkerCpuProfile } = await import('../src/parts/TakeCpuProfile/TakeCpuProfile.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.useFakeTimers()
+  jest.spyOn(Date, 'now').mockReturnValue(123_456)
+  attached = false
+  stopError = undefined
+  downloadsPath = mkdtempSync(join(tmpdir(), 'lvce-cpu-profile-'))
+  mockWindow = {
+    webContents: {
+      debugger: electronDebugger,
+    },
+  }
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+  rmSync(downloadsPath, { force: true, recursive: true })
+})
+
+test('takes a ten second CPU profile of the extension host window', async () => {
+  const resultPromise = takeWindowCpuProfile(7)
+  await jest.advanceTimersByTimeAsync(10_000)
+  const result = await resultPromise
+
+  expect(result).toBe(join(downloadsPath, 'Extension-Host-Window-7-123456.cpuprofile'))
+  expect(JSON.parse(readFileSync(result, 'utf8'))).toEqual(profile)
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(1, 'Profiler.enable', undefined, undefined)
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(2, 'Profiler.start', undefined, undefined)
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(3, 'Profiler.stop', undefined, undefined)
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(4, 'Profiler.disable', undefined, undefined)
+  expect(electronDebugger.attach).toHaveBeenCalledTimes(1)
+  expect(electronDebugger.detach).toHaveBeenCalledTimes(1)
+})
+
+test('takes a ten second CPU profile of the named extension worker', async () => {
+  const resultPromise = takeWorkerCpuProfile(7, 'Extension API (Electron): sample.extension')
+  await jest.advanceTimersByTimeAsync(10_000)
+  const result = await resultPromise
+
+  expect(result).toBe(join(downloadsPath, 'Extension-API-Electron-sample.extension-123456.cpuprofile'))
+  expect(JSON.parse(readFileSync(result, 'utf8'))).toEqual(profile)
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(1, 'Page.getFrameTree')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(2, 'Target.getTargets')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(3, 'Target.attachToTarget', {
+    flatten: true,
+    targetId: 'worker-target',
+  })
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(4, 'Profiler.enable', undefined, 'worker-session')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(5, 'Profiler.start', undefined, 'worker-session')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(6, 'Profiler.stop', undefined, 'worker-session')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(7, 'Profiler.disable', undefined, 'worker-session')
+  expect(electronDebugger.sendCommand).toHaveBeenNthCalledWith(8, 'Target.detachFromTarget', { sessionId: 'worker-session' })
+})
+
+test('reuses an attached debugger', async () => {
+  attached = true
+
+  const resultPromise = takeWindowCpuProfile(7)
+  await jest.advanceTimersByTimeAsync(10_000)
+  await resultPromise
+
+  expect(electronDebugger.attach).not.toHaveBeenCalled()
+  expect(electronDebugger.detach).not.toHaveBeenCalled()
+})
+
+test('throws when the browser window does not exist', async () => {
+  mockWindow = undefined
+
+  await expect(takeWindowCpuProfile(7)).rejects.toThrow('Browser window not found: 7')
+  expect(electronDebugger.attach).not.toHaveBeenCalled()
+})
+
+test('throws when the worker does not exist', async () => {
+  electronDebugger.sendCommand.mockResolvedValueOnce({ frameTree: { frame: { id: 'main-frame' } } }).mockResolvedValueOnce({ targetInfos: [] })
+
+  await expect(takeWorkerCpuProfile(7, 'Extension API (Electron): missing.extension')).rejects.toThrow(
+    'Worker not found: Extension API (Electron): missing.extension',
+  )
+  expect(electronDebugger.detach).toHaveBeenCalledTimes(1)
+})
+
+test('does not leave a profile file when profiling fails', async () => {
+  stopError = new Error('Profiling failed')
+
+  let profileError: unknown
+  const takeProfile = async (): Promise<void> => {
+    try {
+      await takeWindowCpuProfile(7)
+    } catch (error) {
+      profileError = error
+    }
+  }
+  const resultPromise = takeProfile()
+  await jest.advanceTimersByTimeAsync(10_000)
+  await resultPromise
+
+  expect(profileError).toEqual(new Error('Profiling failed'))
+  expect(readdirSync(downloadsPath)).toEqual([])
+})


### PR DESCRIPTION
Adds fixed-duration CPU profiling for an Electron renderer window or a named worker. Profiles are written to Downloads as timestamped .cpuprofile files with debugger and partial-file cleanup.