### PR TITLE
feature: update electron to 43.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6058,9 +6058,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "43.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
-      "integrity": "sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==",
+      "version": "43.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
+      "integrity": "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12610,7 +12610,7 @@
       "devDependencies": {
         "@jest/globals": "^30.4.1",
         "@types/node": "^24.9.2",
-        "electron": "43.1.1",
+        "electron": "43.2.0",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.12"
       },

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@jest/globals": "^30.4.1",
     "@types/node": "^24.9.2",
-    "electron": "43.1.1",
+    "electron": "43.2.0",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.12"
   },


### PR DESCRIPTION
Updates Electron from 43.1.1 to the latest stable release, 43.2.0, including the lockfile metadata.