### PR TITLE
fix: open simple browser popups externally

### DIFF
--- a/packages/main-process/src/parts/ElectronBrowserViewEventListenerWindowOpen/ElectronBrowserViewEventListenerWindowOpen.ts
+++ b/packages/main-process/src/parts/ElectronBrowserViewEventListenerWindowOpen/ElectronBrowserViewEventListenerWindowOpen.ts
@@ -1,6 +1,6 @@
-import * as ElectronDispositionType from '../ElectronDispositionType/ElectronDispositionType.ts'
 import * as ElectronWindowOpenActionType from '../ElectronWindowOpenActionType/ElectronWindowOpenActionType.ts'
-import * as Logger from '../Logger/Logger.ts'
+import { openExternal } from '../OpenExternal/OpenExternal.ts'
+import * as ShouldOpenExternal from '../ShouldOpenExternal/ShouldOpenExternal.ts'
 
 export const key = 'window-open'
 
@@ -12,32 +12,10 @@ export const detach = (webContents, listener) => {
   webContents.setWindowOpenHandler(null)
 }
 
-export const handler = ({ disposition, features, frameName, postBody, referrer, url }) => {
-  if (url === 'about:blank') {
-    return {
-      messages: [],
-      result: {
-        action: ElectronWindowOpenActionType.Allow,
-      },
-    }
+export const handler = ({ url }: { disposition: string; url: string }) => {
+  if (ShouldOpenExternal.shouldOpenExternal(url)) {
+    void openExternal(url)
   }
-  if (disposition === ElectronDispositionType.BackgroundTab) {
-    return {
-      messages: [['handleWindowOpen', url]],
-      result: {
-        action: ElectronWindowOpenActionType.Deny,
-      },
-    }
-  }
-  if (disposition === ElectronDispositionType.NewWindow) {
-    return {
-      messages: [],
-      result: {
-        action: ElectronWindowOpenActionType.Allow,
-      },
-    }
-  }
-  Logger.info(`[main-process] blocked popup for ${url}`)
   return {
     messages: [],
     result: {

--- a/packages/main-process/test/ElectronBrowserViewEventListenerWindowOpen.test.ts
+++ b/packages/main-process/test/ElectronBrowserViewEventListenerWindowOpen.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const openExternal = jest.fn()
+
+jest.unstable_mockModule('../src/parts/OpenExternal/OpenExternal.ts', () => ({
+  openExternal,
+}))
+
+const ElectronBrowserViewEventListenerWindowOpen = await import(
+  '../src/parts/ElectronBrowserViewEventListenerWindowOpen/ElectronBrowserViewEventListenerWindowOpen.ts'
+)
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test.each(['background-tab', 'default', 'foreground-tab', 'new-window'])('blocks %s and opens the url externally', (disposition) => {
+  const result = ElectronBrowserViewEventListenerWindowOpen.handler({
+    disposition,
+    url: 'https://accounts.google.com/o/oauth2/v2/auth',
+  })
+
+  expect(result).toEqual({
+    messages: [],
+    result: {
+      action: 'deny',
+    },
+  })
+  expect(openExternal).toHaveBeenCalledTimes(1)
+  expect(openExternal).toHaveBeenCalledWith('https://accounts.google.com/o/oauth2/v2/auth')
+})
+
+test('blocks about:blank without opening it externally', () => {
+  const result = ElectronBrowserViewEventListenerWindowOpen.handler({
+    disposition: 'new-window',
+    url: 'about:blank',
+  })
+
+  expect(result).toEqual({
+    messages: [],
+    result: {
+      action: 'deny',
+    },
+  })
+  expect(openExternal).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Summary:
- block Simple Browser popups instead of creating Electron child windows
- open HTTP and HTTPS popup targets in the system browser
- cover popup dispositions and about:blank handling