### PR TITLE
feature: import Chrome cookies

### DIFF
--- a/packages/main-process/src/parts/ChromeCookieConversion/ChromeCookieConversion.ts
+++ b/packages/main-process/src/parts/ChromeCookieConversion/ChromeCookieConversion.ts
@@ -1,0 +1,61 @@
+import type { ChromeCookieRow } from '../ChromeCookieDatabase/ChromeCookieDatabase.ts'
+import * as ChromeCookieDecrypt from '../ChromeCookieDecrypt/ChromeCookieDecrypt.ts'
+
+const chromeEpochOffsetMicroseconds = 11_644_473_600_000_000n
+const microsecondsPerSecond = 1_000_000n
+
+const getSameSite = (sameSite: number): Electron.CookiesSetDetails['sameSite'] => {
+  switch (sameSite) {
+    case 0:
+      return 'no_restriction'
+    case 1:
+      return 'lax'
+    case 2:
+      return 'strict'
+    default:
+      return 'unspecified'
+  }
+}
+
+const getExpirationDate = (expiresUtc: string): number => {
+  const chromeMicroseconds = BigInt(expiresUtc)
+  return Number(chromeMicroseconds - chromeEpochOffsetMicroseconds) / Number(microsecondsPerSecond)
+}
+
+const getValue = (row: ChromeCookieRow, databaseVersion: number): string => {
+  if (row.value) {
+    return row.value
+  }
+  return ChromeCookieDecrypt.decrypt(row.hostKey, row.encryptedValue, databaseVersion)
+}
+
+export const convert = (row: ChromeCookieRow, databaseVersion: number, now: number = Date.now() / 1000): Electron.CookiesSetDetails | undefined => {
+  if (!row.hostKey || row.topFrameSiteKey) {
+    return undefined
+  }
+  const host = row.hostKey.startsWith('.') ? row.hostKey.slice(1) : row.hostKey
+  if (!host) {
+    return undefined
+  }
+  const secure = Boolean(row.isSecure)
+  const details: Electron.CookiesSetDetails = {
+    httpOnly: Boolean(row.isHttpOnly),
+    name: row.name,
+    path: row.path || '/',
+    sameSite: getSameSite(row.sameSite),
+    secure,
+    url: `${secure ? 'https' : 'http'}://${host}/`,
+    value: getValue(row, databaseVersion),
+  }
+  if (row.hostKey.startsWith('.')) {
+    details.domain = row.hostKey
+  }
+  if (row.hasExpires) {
+    const expirationDate = getExpirationDate(row.expiresUtc)
+    if (!Number.isFinite(expirationDate) || expirationDate <= now) {
+      return undefined
+    }
+    details.expirationDate = expirationDate
+  }
+  return details
+}

--- a/packages/main-process/src/parts/ChromeCookieDatabase/ChromeCookieDatabase.ts
+++ b/packages/main-process/src/parts/ChromeCookieDatabase/ChromeCookieDatabase.ts
@@ -1,0 +1,91 @@
+/* eslint-disable n/no-unsupported-features/node-builtins -- Electron 43 provides the node:sqlite API used by the main process */
+import { DatabaseSync } from 'node:sqlite'
+
+export interface ChromeCookieRow {
+  readonly encryptedValue: Uint8Array
+  readonly expiresUtc: string
+  readonly hasExpires: number
+  readonly hostKey: string
+  readonly isHttpOnly: number
+  readonly isSecure: number
+  readonly name: string
+  readonly path: string
+  readonly sameSite: number
+  readonly topFrameSiteKey: string
+  readonly value: string
+}
+
+export interface ChromeCookieDatabase {
+  readonly rows: readonly ChromeCookieRow[]
+  readonly version: number
+}
+
+const getDatabaseError = (error: unknown): Error => {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message.toLowerCase().includes('locked') || message.toLowerCase().includes('busy')) {
+    return new Error('Chrome cookie database is busy. Close Chrome and try again.')
+  }
+  return new Error('Failed to read the Chrome cookie database')
+}
+
+const withDatabase = <T>(path: string, fn: (database: DatabaseSync) => T): T => {
+  let database: DatabaseSync | undefined
+  try {
+    database = new DatabaseSync(path, { readOnly: true })
+    database.exec('PRAGMA busy_timeout = 1000')
+    return fn(database)
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Unsupported Chrome cookie database version')) {
+      throw error
+    }
+    throw getDatabaseError(error)
+  } finally {
+    database?.close()
+  }
+}
+
+const getVersion = (database: DatabaseSync): number => {
+  const row = database.prepare(`SELECT value FROM meta WHERE key = 'version'`).get() as { readonly value?: string } | undefined
+  const version = Number(row?.value)
+  if (version !== 24) {
+    throw new Error(`Unsupported Chrome cookie database version ${Number.isFinite(version) ? version : 'unknown'}`)
+  }
+  return version
+}
+
+export const getCookieCount = (path: string): number => {
+  return withDatabase(path, (database) => {
+    getVersion(database)
+    const row = database.prepare('SELECT COUNT(*) AS count FROM cookies').get() as { readonly count: number }
+    return row.count
+  })
+}
+
+export const readCookies = (path: string): ChromeCookieDatabase => {
+  return withDatabase(path, (database) => {
+    const version = getVersion(database)
+    const rows = database
+      .prepare(
+        `
+        SELECT
+          encrypted_value AS encryptedValue,
+          CAST(expires_utc AS TEXT) AS expiresUtc,
+          has_expires AS hasExpires,
+          host_key AS hostKey,
+          is_httponly AS isHttpOnly,
+          is_secure AS isSecure,
+          name,
+          path,
+          samesite AS sameSite,
+          top_frame_site_key AS topFrameSiteKey,
+          value
+        FROM cookies
+      `,
+      )
+      .all() as unknown as readonly ChromeCookieRow[]
+    return {
+      rows,
+      version,
+    }
+  })
+}

--- a/packages/main-process/src/parts/ChromeCookieDecrypt/ChromeCookieDecrypt.ts
+++ b/packages/main-process/src/parts/ChromeCookieDecrypt/ChromeCookieDecrypt.ts
@@ -1,0 +1,34 @@
+import { createDecipheriv, createHash, pbkdf2Sync } from 'node:crypto'
+
+const chromeV10Prefix = Buffer.from('v10')
+const chromeV10Key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1')
+const chromeV10Iv = Buffer.alloc(16, 0x20)
+const domainHashLength = 32
+
+export class UnsupportedChromeCookieEncryptionError extends Error {
+  constructor() {
+    super('Unsupported Chrome cookie encryption format')
+    this.name = 'UnsupportedChromeCookieEncryptionError'
+  }
+}
+
+export const decrypt = (hostKey: string, encryptedValue: Uint8Array, databaseVersion: number): string => {
+  const buffer = Buffer.from(encryptedValue)
+  if (buffer.length <= chromeV10Prefix.length || !buffer.subarray(0, chromeV10Prefix.length).equals(chromeV10Prefix)) {
+    throw new UnsupportedChromeCookieEncryptionError()
+  }
+  const decipher = createDecipheriv('aes-128-cbc', chromeV10Key, chromeV10Iv)
+  const plaintext = Buffer.concat([decipher.update(buffer.subarray(chromeV10Prefix.length)), decipher.final()])
+  if (databaseVersion < 24) {
+    return plaintext.toString('utf8')
+  }
+  if (plaintext.length < domainHashLength) {
+    throw new Error('Chrome cookie domain integrity check failed')
+  }
+  const expectedDomainHash = createHash('sha256').update(hostKey).digest()
+  const actualDomainHash = plaintext.subarray(0, domainHashLength)
+  if (!actualDomainHash.equals(expectedDomainHash)) {
+    throw new Error('Chrome cookie domain integrity check failed')
+  }
+  return plaintext.subarray(domainHashLength).toString('utf8')
+}

--- a/packages/main-process/src/parts/ChromeCookieImport/ChromeCookieImport.ts
+++ b/packages/main-process/src/parts/ChromeCookieImport/ChromeCookieImport.ts
@@ -1,0 +1,88 @@
+import type { Session } from 'electron'
+import * as ChromeCookieConversion from '../ChromeCookieConversion/ChromeCookieConversion.ts'
+import * as ChromeCookieDatabase from '../ChromeCookieDatabase/ChromeCookieDatabase.ts'
+import { UnsupportedChromeCookieEncryptionError } from '../ChromeCookieDecrypt/ChromeCookieDecrypt.ts'
+import * as ChromeCookieProfile from '../ChromeCookieProfile/ChromeCookieProfile.ts'
+import * as ElectronSessionForBrowserView from '../ElectronSessionForBrowserView/ElectronSessionForBrowserView.ts'
+
+export interface ChromeCookieImportInfo {
+  readonly cookieCount: number
+  readonly profileDirectory: string
+  readonly profileName: string
+}
+
+export interface ChromeCookieImportResult {
+  readonly failed: number
+  readonly imported: number
+  readonly skipped: number
+}
+
+type CookieSession = Pick<Session, 'cookies'>
+
+const assertLinux = (): void => {
+  if (process.platform !== 'linux') {
+    throw new Error('Importing Chrome cookies is only supported on Linux')
+  }
+}
+
+export const getInfoFromDirectory = (chromeDataDirectory: string): ChromeCookieImportInfo => {
+  const profile = ChromeCookieProfile.getActiveProfile(chromeDataDirectory)
+  const cookieCount = ChromeCookieDatabase.getCookieCount(profile.cookieDatabasePath)
+  return {
+    cookieCount,
+    profileDirectory: profile.directory,
+    profileName: profile.name,
+  }
+}
+
+export const getInfo = (): ChromeCookieImportInfo => {
+  assertLinux()
+  return getInfoFromDirectory(ChromeCookieProfile.getChromeDataDirectory())
+}
+
+export const importFromDirectory = async (chromeDataDirectory: string, session: CookieSession): Promise<ChromeCookieImportResult> => {
+  const profile = ChromeCookieProfile.getActiveProfile(chromeDataDirectory)
+  const { rows, version } = ChromeCookieDatabase.readCookies(profile.cookieDatabasePath)
+  const cookies: Electron.CookiesSetDetails[] = []
+  let skipped = 0
+  let unsupportedEncryption = 0
+  for (const row of rows) {
+    try {
+      const cookie = ChromeCookieConversion.convert(row, version)
+      if (cookie) {
+        cookies.push(cookie)
+      } else {
+        skipped++
+      }
+    } catch (error) {
+      skipped++
+      if (error instanceof UnsupportedChromeCookieEncryptionError) {
+        unsupportedEncryption++
+      }
+    }
+  }
+  if (cookies.length === 0 && unsupportedEncryption > 0) {
+    throw new Error('Unsupported Chrome cookie encryption format')
+  }
+  let imported = 0
+  let failed = 0
+  for (const cookie of cookies) {
+    try {
+      await session.cookies.set(cookie)
+      imported++
+    } catch {
+      failed++
+    }
+  }
+  await session.cookies.flushStore()
+  return {
+    failed,
+    imported,
+    skipped,
+  }
+}
+
+export const importCookies = async (): Promise<ChromeCookieImportResult> => {
+  assertLinux()
+  return importFromDirectory(ChromeCookieProfile.getChromeDataDirectory(), ElectronSessionForBrowserView.getSession())
+}

--- a/packages/main-process/src/parts/ChromeCookieProfile/ChromeCookieProfile.ts
+++ b/packages/main-process/src/parts/ChromeCookieProfile/ChromeCookieProfile.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+interface ChromeProfileInfo {
+  readonly active_time?: number
+  readonly name?: string
+}
+
+interface ChromeLocalState {
+  readonly profile?: {
+    readonly info_cache?: Readonly<Record<string, ChromeProfileInfo>>
+    readonly profiles_order?: readonly string[]
+  }
+}
+
+export interface ChromeProfile {
+  readonly cookieDatabasePath: string
+  readonly directory: string
+  readonly name: string
+}
+
+const isValidProfileDirectory = (value: string): boolean => {
+  return value !== '' && value !== '.' && value !== '..' && !value.includes('/') && !value.includes('\\')
+}
+
+const getCookieDatabasePath = (chromeDataDirectory: string, profileDirectory: string): string => {
+  const profilePath = join(chromeDataDirectory, profileDirectory)
+  const candidates = [join(profilePath, 'Cookies'), join(profilePath, 'Network', 'Cookies')]
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  throw new Error(`Chrome cookie database was not found for profile ${profileDirectory}`)
+}
+
+const getMostRecentlyActiveProfile = (infoCache: Readonly<Record<string, ChromeProfileInfo>>): string | undefined => {
+  let selected: string | undefined
+  let selectedActiveTime = -Infinity
+  for (const [directory, info] of Object.entries(infoCache)) {
+    if (!isValidProfileDirectory(directory)) {
+      continue
+    }
+    const activeTime = typeof info.active_time === 'number' && Number.isFinite(info.active_time) ? info.active_time : -Infinity
+    if (selected === undefined || activeTime > selectedActiveTime) {
+      selected = directory
+      selectedActiveTime = activeTime
+    }
+  }
+  return selected
+}
+
+export const getChromeDataDirectory = (): string => {
+  const configDirectory = process.env.XDG_CONFIG_HOME || join(homedir(), '.config')
+  return join(configDirectory, 'google-chrome')
+}
+
+export const getActiveProfile = (chromeDataDirectory: string): ChromeProfile => {
+  const localStatePath = join(chromeDataDirectory, 'Local State')
+  if (!existsSync(localStatePath)) {
+    throw new Error(`Google Chrome profile data was not found at ${chromeDataDirectory}`)
+  }
+  let localState: ChromeLocalState
+  try {
+    localState = JSON.parse(readFileSync(localStatePath, 'utf8'))
+  } catch {
+    throw new Error('Google Chrome profile metadata is invalid')
+  }
+  const infoCache = localState.profile?.info_cache || {}
+  const orderedProfile = localState.profile?.profiles_order?.find(isValidProfileDirectory)
+  const directory = getMostRecentlyActiveProfile(infoCache) || orderedProfile || 'Default'
+  const name = infoCache[directory]?.name || directory
+  const cookieDatabasePath = getCookieDatabasePath(chromeDataDirectory, directory)
+  return {
+    cookieDatabasePath,
+    directory,
+    name,
+  }
+}

--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -1,5 +1,6 @@
 import * as AppWindow from '../AppWindow/AppWindow.ts'
 import * as Beep from '../Beep/Beep.ts'
+import * as ChromeCookieImport from '../ChromeCookieImport/ChromeCookieImport.ts'
 import * as Crash from '../Crash/Crash.ts'
 import * as CreateMessagePort from '../CreateMessagePort/CreateMessagePort.ts'
 import * as CreatePidMap from '../CreatePidMap/CreatePidMap.ts'
@@ -38,6 +39,8 @@ import * as Trash from '../Trash/Trash.ts'
 export const commandMap = {
   'AppWindow.createAppWindow': AppWindow.createAppWindow,
   'Beep.beep': Beep.beep,
+  'ChromeCookieImport.getInfo': ChromeCookieImport.getInfo,
+  'ChromeCookieImport.importCookies': ChromeCookieImport.importCookies,
   'Crash.crashMainProcess': Crash.crashMainProcess,
   'CreateMessagePort.createMessagePort': CreateMessagePort.createMessagePort,
   'CreatePidMap.createPidMap': CreatePidMap.createPidMap,

--- a/packages/main-process/test/ChromeCookieImport.test.ts
+++ b/packages/main-process/test/ChromeCookieImport.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { createCipheriv, createHash, pbkdf2Sync } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const temporaryDirectories: string[] = []
+const chromeEpochOffsetMicroseconds = 11_644_473_600_000_000n
+const getCookieCount = jest.fn<(path: string) => number>()
+const readCookies = jest.fn<(path: string) => { readonly rows: readonly any[]; readonly version: number }>()
+
+jest.unstable_mockModule('electron', () => {
+  return {
+    session: {
+      fromPartition: jest.fn(),
+    },
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ChromeCookieDatabase/ChromeCookieDatabase.ts', () => {
+  return {
+    getCookieCount,
+    readCookies,
+  }
+})
+
+const ChromeCookieDecrypt = await import('../src/parts/ChromeCookieDecrypt/ChromeCookieDecrypt.ts')
+const ChromeCookieImport = await import('../src/parts/ChromeCookieImport/ChromeCookieImport.ts')
+
+interface CookieFixture {
+  readonly encryptedValue?: Uint8Array
+  readonly expiresUtc?: string
+  readonly hasExpires?: number
+  readonly hostKey?: string
+  readonly isHttpOnly?: number
+  readonly isSecure?: number
+  readonly name?: string
+  readonly path?: string
+  readonly sameSite?: number
+  readonly topFrameSiteKey?: string
+  readonly value?: string
+}
+
+const createTemporaryDirectory = (): string => {
+  const directory = mkdtempSync(join(tmpdir(), 'chrome-cookie-import-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+const encryptCookie = (hostKey: string, value: string): Buffer => {
+  const key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1')
+  const iv = Buffer.alloc(16, 0x20)
+  const cipher = createCipheriv('aes-128-cbc', key, iv) // eslint-disable-line sonarjs/encryption-secure-mode -- reproduces Chrome's v10 cookie format
+  const plaintext = Buffer.concat([createHash('sha256').update(hostKey).digest(), Buffer.from(value)])
+  return Buffer.concat([Buffer.from('v10'), cipher.update(plaintext), cipher.final()])
+}
+
+const getChromeTimestamp = (unixSeconds: number): string => {
+  return (BigInt(Math.floor(unixSeconds)) * 1_000_000n + chromeEpochOffsetMicroseconds).toString()
+}
+
+const createCookie = (fixture: CookieFixture = {}): any => {
+  const hostKey = fixture.hostKey || 'example.com'
+  return {
+    encryptedValue: fixture.encryptedValue || encryptCookie(hostKey, 'secret'),
+    expiresUtc: fixture.expiresUtc || '0',
+    hasExpires: fixture.hasExpires || 0,
+    hostKey,
+    isHttpOnly: fixture.isHttpOnly || 0,
+    isSecure: fixture.isSecure || 0,
+    name: fixture.name ?? 'session',
+    path: fixture.path || '/',
+    sameSite: fixture.sameSite ?? -1,
+    topFrameSiteKey: fixture.topFrameSiteKey || '',
+    value: fixture.value || '',
+  }
+}
+
+const createChromeProfile = (
+  profiles: Readonly<Record<string, { readonly active_time: number; readonly name: string }>>,
+  profileDirectory: string,
+): string => {
+  const chromeDataDirectory = createTemporaryDirectory()
+  writeFileSync(
+    join(chromeDataDirectory, 'Local State'),
+    JSON.stringify({
+      profile: {
+        info_cache: profiles,
+        profiles_order: Object.keys(profiles),
+      },
+    }),
+  )
+  const profilePath = join(chromeDataDirectory, profileDirectory)
+  mkdirSync(profilePath, { recursive: true })
+  writeFileSync(join(profilePath, 'Cookies'), '')
+  return chromeDataDirectory
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { force: true, recursive: true })
+  }
+  temporaryDirectories.length = 0
+  jest.resetAllMocks()
+})
+
+test('getInfoFromDirectory selects the most recently active profile', () => {
+  const chromeDataDirectory = createChromeProfile(
+    {
+      Default: {
+        active_time: 1,
+        name: 'Default profile',
+      },
+      'Profile 1': {
+        active_time: 2,
+        name: 'Work',
+      },
+    },
+    'Profile 1',
+  )
+  getCookieCount.mockReturnValue(2)
+
+  expect(ChromeCookieImport.getInfoFromDirectory(chromeDataDirectory)).toEqual({
+    cookieCount: 2,
+    profileDirectory: 'Profile 1',
+    profileName: 'Work',
+  })
+  expect(getCookieCount).toHaveBeenCalledWith(join(chromeDataDirectory, 'Profile 1', 'Cookies'))
+})
+
+test('getInfoFromDirectory propagates unsupported database errors', () => {
+  const chromeDataDirectory = createChromeProfile(
+    {
+      Default: {
+        active_time: 1,
+        name: 'Default profile',
+      },
+    },
+    'Default',
+  )
+  getCookieCount.mockImplementation(() => {
+    throw new Error('Unsupported Chrome cookie database version 23')
+  })
+
+  expect(() => ChromeCookieImport.getInfoFromDirectory(chromeDataDirectory)).toThrow('Unsupported Chrome cookie database version 23')
+})
+
+test('decrypt validates the version 24 domain hash', () => {
+  const encryptedValue = encryptCookie('.example.com', 'secret')
+
+  expect(ChromeCookieDecrypt.decrypt('.example.com', encryptedValue, 24)).toBe('secret')
+  expect(() => ChromeCookieDecrypt.decrypt('.other.example.com', encryptedValue, 24)).toThrow('Chrome cookie domain integrity check failed')
+})
+
+test('importFromDirectory imports eligible cookies and skips unsupported cookies', async () => {
+  const now = Date.now() / 1000
+  const chromeDataDirectory = createChromeProfile(
+    {
+      Default: {
+        active_time: 1,
+        name: 'Default profile',
+      },
+    },
+    'Default',
+  )
+  readCookies.mockReturnValue({
+    rows: [
+      createCookie({
+        expiresUtc: getChromeTimestamp(now + 3600),
+        hasExpires: 1,
+        hostKey: '.example.com',
+        isHttpOnly: 1,
+        isSecure: 1,
+        name: 'persistent',
+        path: '/account',
+        sameSite: 1,
+      }),
+      createCookie({
+        hostKey: 'example.org',
+        name: 'host-only',
+        value: 'plaintext',
+      }),
+      createCookie({
+        expiresUtc: getChromeTimestamp(now - 3600),
+        hasExpires: 1,
+        name: 'expired',
+      }),
+      createCookie({
+        name: 'partitioned',
+        topFrameSiteKey: 'https://top.example',
+      }),
+      createCookie({
+        encryptedValue: Buffer.from('v11unsupported'),
+        name: 'unsupported',
+      }),
+    ],
+    version: 24,
+  })
+  const set = jest.fn<(...args: readonly any[]) => Promise<void>>().mockResolvedValue(undefined)
+  const flushStore = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+  await expect(
+    ChromeCookieImport.importFromDirectory(chromeDataDirectory, {
+      cookies: {
+        flushStore,
+        set,
+      } as any,
+    }),
+  ).resolves.toEqual({
+    failed: 0,
+    imported: 2,
+    skipped: 3,
+  })
+  expect(set).toHaveBeenNthCalledWith(1, {
+    domain: '.example.com',
+    expirationDate: expect.any(Number),
+    httpOnly: true,
+    name: 'persistent',
+    path: '/account',
+    sameSite: 'lax',
+    secure: true,
+    url: 'https://example.com/',
+    value: 'secret',
+  })
+  expect(set).toHaveBeenNthCalledWith(2, {
+    httpOnly: false,
+    name: 'host-only',
+    path: '/',
+    sameSite: 'unspecified',
+    secure: false,
+    url: 'http://example.org/',
+    value: 'plaintext',
+  })
+  expect(flushStore).toHaveBeenCalledTimes(1)
+})
+
+test('importFromDirectory reports destination failures and still flushes', async () => {
+  const chromeDataDirectory = createChromeProfile(
+    {
+      Default: {
+        active_time: 1,
+        name: 'Default profile',
+      },
+    },
+    'Default',
+  )
+  readCookies.mockReturnValue({
+    rows: [createCookie({ name: 'one' }), createCookie({ name: 'two' })],
+    version: 24,
+  })
+  const set = jest.fn<(...args: readonly any[]) => Promise<void>>().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('failed'))
+  const flushStore = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+  await expect(
+    ChromeCookieImport.importFromDirectory(chromeDataDirectory, {
+      cookies: {
+        flushStore,
+        set,
+      } as any,
+    }),
+  ).resolves.toEqual({
+    failed: 1,
+    imported: 1,
+    skipped: 0,
+  })
+  expect(flushStore).toHaveBeenCalledTimes(1)
+})
+
+test('importFromDirectory fails closed when every encrypted cookie is unsupported', async () => {
+  const chromeDataDirectory = createChromeProfile(
+    {
+      Default: {
+        active_time: 1,
+        name: 'Default profile',
+      },
+    },
+    'Default',
+  )
+  readCookies.mockReturnValue({
+    rows: [
+      createCookie({
+        encryptedValue: Buffer.from('v11unsupported'),
+      }),
+    ],
+    version: 24,
+  })
+  const flushStore = jest.fn<() => Promise<void>>()
+  const set = jest.fn<(...args: readonly any[]) => Promise<void>>()
+
+  await expect(
+    ChromeCookieImport.importFromDirectory(chromeDataDirectory, {
+      cookies: {
+        flushStore,
+        set,
+      } as any,
+    }),
+  ).rejects.toThrow('Unsupported Chrome cookie encryption format')
+  expect(set).not.toHaveBeenCalled()
+  expect(flushStore).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Adds a Linux Chrome cookie importer for the Simple Browser session. The importer discovers the active Chrome profile, validates and decrypts supported cookies entirely in the main process, merges them into the persistent browser session, and returns aggregate results only.