### PR TITLE
feature: import Firefox cookies

### DIFF
--- a/packages/main-process/src/parts/CommandMap/CommandMap.ts
+++ b/packages/main-process/src/parts/CommandMap/CommandMap.ts
@@ -28,6 +28,7 @@ import * as ElectronWindow from '../ElectronWindow/ElectronWindow.ts'
 import * as ElectronWindowGpuInfo from '../ElectronWindowGpuInfo/ElectronWindowGpuInfo.ts'
 import * as ElectronWindowProcessExplorer from '../ElectronWindowProcessExplorer/ElectronWindowProcessExplorer.ts'
 import * as Exit from '../Exit/Exit.ts'
+import * as FirefoxCookieImport from '../FirefoxCookieImport/FirefoxCookieImport.ts'
 import * as GetWindowId from '../GetWindowId/GetWindowId.ts'
 import * as HandleElectronMessagePort from '../HandleElectronMessagePort/HandleElectronMessagePort.ts'
 import * as IpcParent from '../IpcParent/IpcParent.ts'
@@ -140,6 +141,8 @@ export const commandMap = {
   'ElectronWindowGpuInfo.open': ElectronWindowGpuInfo.open,
   'ElectronWindowProcessExplorer.open2': ElectronWindowProcessExplorer.open2,
   'Exit.exit': Exit.exit,
+  'FirefoxCookieImport.getInfo': FirefoxCookieImport.getInfo,
+  'FirefoxCookieImport.importCookies': FirefoxCookieImport.importCookies,
   'GetWindowId.getWindowId': GetWindowId.getWindowId,
   'HandleElectronMessagePort.handleElectronMessagePort': HandleElectronMessagePort.handleElectronMessagePort,
   'IpcParent.create': IpcParent.create,

--- a/packages/main-process/src/parts/FirefoxCookieConversion/FirefoxCookieConversion.ts
+++ b/packages/main-process/src/parts/FirefoxCookieConversion/FirefoxCookieConversion.ts
@@ -1,0 +1,53 @@
+import type { FirefoxCookieRow } from '../FirefoxCookieDatabase/FirefoxCookieDatabase.ts'
+
+const millisecondsExpirySchemaVersion = 16
+
+const getSameSite = (sameSite: number): Electron.CookiesSetDetails['sameSite'] => {
+  switch (sameSite) {
+    case 0:
+      return 'no_restriction'
+    case 1:
+      return 'lax'
+    case 2:
+      return 'strict'
+    default:
+      return 'unspecified'
+  }
+}
+
+const getExpirationDate = (expiry: number, databaseVersion: number): number => {
+  return databaseVersion >= millisecondsExpirySchemaVersion ? expiry / 1000 : expiry
+}
+
+const getUrlHost = (host: string): string => {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+}
+
+export const convert = (row: FirefoxCookieRow, databaseVersion: number, now: number = Date.now() / 1000): Electron.CookiesSetDetails | undefined => {
+  if (!row.host || row.originAttributes) {
+    return undefined
+  }
+  const host = row.host.startsWith('.') ? row.host.slice(1) : row.host
+  if (!host) {
+    return undefined
+  }
+  const expirationDate = getExpirationDate(row.expiry, databaseVersion)
+  if (!Number.isFinite(expirationDate) || expirationDate <= now) {
+    return undefined
+  }
+  const secure = Boolean(row.isSecure)
+  const details: Electron.CookiesSetDetails = {
+    expirationDate,
+    httpOnly: Boolean(row.isHttpOnly),
+    name: row.name,
+    path: row.path || '/',
+    sameSite: getSameSite(row.sameSite),
+    secure,
+    url: `${secure ? 'https' : 'http'}://${getUrlHost(host)}/`,
+    value: row.value,
+  }
+  if (row.host.startsWith('.')) {
+    details.domain = row.host
+  }
+  return details
+}

--- a/packages/main-process/src/parts/FirefoxCookieDatabase/FirefoxCookieDatabase.ts
+++ b/packages/main-process/src/parts/FirefoxCookieDatabase/FirefoxCookieDatabase.ts
@@ -1,0 +1,86 @@
+/* eslint-disable n/no-unsupported-features/node-builtins -- Electron 43 provides the node:sqlite API used by the main process */
+import { DatabaseSync } from 'node:sqlite'
+
+export interface FirefoxCookieRow {
+  readonly expiry: number
+  readonly host: string
+  readonly isHttpOnly: number
+  readonly isSecure: number
+  readonly name: string
+  readonly originAttributes: string
+  readonly path: string
+  readonly sameSite: number
+  readonly value: string
+}
+
+export interface FirefoxCookieDatabase {
+  readonly rows: readonly FirefoxCookieRow[]
+  readonly version: number
+}
+
+const getDatabaseError = (error: unknown): Error => {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message.toLowerCase().includes('locked') || message.toLowerCase().includes('busy')) {
+    return new Error('Firefox cookie database is busy. Close Firefox and try again.')
+  }
+  return new Error('Failed to read the Firefox cookie database')
+}
+
+const withDatabase = <T>(path: string, fn: (database: DatabaseSync) => T): T => {
+  let database: DatabaseSync | undefined
+  try {
+    database = new DatabaseSync(path, { readOnly: true })
+    database.exec('PRAGMA busy_timeout = 1000')
+    return fn(database)
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Unsupported Firefox cookie database version')) {
+      throw error
+    }
+    throw getDatabaseError(error)
+  } finally {
+    database?.close()
+  }
+}
+
+const getVersion = (database: DatabaseSync): number => {
+  const row = database.prepare('PRAGMA user_version').get() as { readonly user_version: number }
+  if (row.user_version < 9) {
+    throw new Error(`Unsupported Firefox cookie database version ${row.user_version}`)
+  }
+  return row.user_version
+}
+
+export const getCookieCount = (path: string): number => {
+  return withDatabase(path, (database) => {
+    getVersion(database)
+    const row = database.prepare('SELECT COUNT(*) AS count FROM moz_cookies').get() as { readonly count: number }
+    return row.count
+  })
+}
+
+export const readCookies = (path: string): FirefoxCookieDatabase => {
+  return withDatabase(path, (database) => {
+    const version = getVersion(database)
+    const rows = database
+      .prepare(
+        `
+        SELECT
+          expiry,
+          host,
+          isHttpOnly,
+          isSecure,
+          name,
+          originAttributes,
+          path,
+          sameSite,
+          value
+        FROM moz_cookies
+      `,
+      )
+      .all() as unknown as readonly FirefoxCookieRow[]
+    return {
+      rows,
+      version,
+    }
+  })
+}

--- a/packages/main-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ts
+++ b/packages/main-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ts
@@ -1,0 +1,68 @@
+import type { Session } from 'electron'
+import * as ElectronSessionForBrowserView from '../ElectronSessionForBrowserView/ElectronSessionForBrowserView.ts'
+import * as FirefoxCookieConversion from '../FirefoxCookieConversion/FirefoxCookieConversion.ts'
+import * as FirefoxCookieDatabase from '../FirefoxCookieDatabase/FirefoxCookieDatabase.ts'
+import * as FirefoxCookieProfile from '../FirefoxCookieProfile/FirefoxCookieProfile.ts'
+
+export interface FirefoxCookieImportInfo {
+  readonly cookieCount: number
+  readonly profileDirectory: string
+  readonly profileName: string
+}
+
+export interface FirefoxCookieImportResult {
+  readonly failed: number
+  readonly imported: number
+  readonly skipped: number
+}
+
+type CookieSession = Pick<Session, 'cookies'>
+
+export const getInfoFromDirectory = (firefoxDataDirectory: string): FirefoxCookieImportInfo => {
+  const profile = FirefoxCookieProfile.getActiveProfile(firefoxDataDirectory)
+  const cookieCount = FirefoxCookieDatabase.getCookieCount(profile.cookieDatabasePath)
+  return {
+    cookieCount,
+    profileDirectory: profile.directory,
+    profileName: profile.name,
+  }
+}
+
+export const getInfo = (): FirefoxCookieImportInfo => {
+  return getInfoFromDirectory(FirefoxCookieProfile.getFirefoxDataDirectory())
+}
+
+export const importFromDirectory = async (firefoxDataDirectory: string, session: CookieSession): Promise<FirefoxCookieImportResult> => {
+  const profile = FirefoxCookieProfile.getActiveProfile(firefoxDataDirectory)
+  const { rows, version } = FirefoxCookieDatabase.readCookies(profile.cookieDatabasePath)
+  const cookies: Electron.CookiesSetDetails[] = []
+  let skipped = 0
+  for (const row of rows) {
+    const cookie = FirefoxCookieConversion.convert(row, version)
+    if (cookie) {
+      cookies.push(cookie)
+    } else {
+      skipped++
+    }
+  }
+  let imported = 0
+  let failed = 0
+  for (const cookie of cookies) {
+    try {
+      await session.cookies.set(cookie)
+      imported++
+    } catch {
+      failed++
+    }
+  }
+  await session.cookies.flushStore()
+  return {
+    failed,
+    imported,
+    skipped,
+  }
+}
+
+export const importCookies = async (): Promise<FirefoxCookieImportResult> => {
+  return importFromDirectory(FirefoxCookieProfile.getFirefoxDataDirectory(), ElectronSessionForBrowserView.getSession())
+}

--- a/packages/main-process/src/parts/FirefoxCookieProfile/FirefoxCookieProfile.ts
+++ b/packages/main-process/src/parts/FirefoxCookieProfile/FirefoxCookieProfile.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { isAbsolute, join } from 'node:path'
+
+interface IniSection {
+  readonly [key: string]: string
+}
+
+export interface FirefoxProfile {
+  readonly cookieDatabasePath: string
+  readonly directory: string
+  readonly name: string
+}
+
+const parseIni = (content: string): Readonly<Record<string, IniSection>> => {
+  const sections: Record<string, Record<string, string>> = {}
+  let section: Record<string, string> | undefined
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    const sectionMatch = /^\[([^\]]+)\]$/.exec(trimmed)
+    if (sectionMatch) {
+      section = {}
+      sections[sectionMatch[1]] = section
+    } else if (section && trimmed && !trimmed.startsWith(';') && !trimmed.startsWith('#')) {
+      const separatorIndex = trimmed.indexOf('=')
+      if (separatorIndex !== -1) {
+        section[trimmed.slice(0, separatorIndex)] = trimmed.slice(separatorIndex + 1)
+      }
+    }
+  }
+  return sections
+}
+
+const getProfilePath = (firefoxDataDirectory: string, profile: IniSection): string => {
+  if (profile.IsRelative === '0' || isAbsolute(profile.Path)) {
+    return profile.Path
+  }
+  return join(firefoxDataDirectory, profile.Path)
+}
+
+export const getFirefoxDataDirectory = (): string => {
+  const homeDirectory = homedir()
+  if (process.platform === 'win32') {
+    const applicationDataDirectory = process.env.APPDATA || join(homeDirectory, 'AppData', 'Roaming')
+    return join(applicationDataDirectory, 'Mozilla', 'Firefox')
+  }
+  if (process.platform === 'darwin') {
+    return join(homeDirectory, 'Library', 'Application Support', 'Firefox')
+  }
+  const candidates = [
+    join(homeDirectory, '.mozilla', 'firefox'),
+    join(homeDirectory, 'snap', 'firefox', 'common', '.mozilla', 'firefox'),
+    join(homeDirectory, '.var', 'app', 'org.mozilla.firefox', '.mozilla', 'firefox'),
+  ]
+  const directory = candidates.find((candidate) => existsSync(join(candidate, 'profiles.ini')))
+  return directory || candidates[0]
+}
+
+export const getActiveProfile = (firefoxDataDirectory: string): FirefoxProfile => {
+  const profilesPath = join(firefoxDataDirectory, 'profiles.ini')
+  if (!existsSync(profilesPath)) {
+    throw new Error(`Firefox profile data was not found at ${firefoxDataDirectory}`)
+  }
+  let sections: Readonly<Record<string, IniSection>>
+  try {
+    sections = parseIni(readFileSync(profilesPath, 'utf8'))
+  } catch {
+    throw new Error('Firefox profile metadata is invalid')
+  }
+  const profiles = Object.entries(sections).filter(([sectionName, profile]) => sectionName.startsWith('Profile') && profile.Path)
+  const installs = Object.entries(sections).filter(([sectionName, install]) => sectionName.startsWith('Install') && install.Default)
+  const installDefault = (installs.find(([, install]) => install.Locked === '1') || installs[0])?.[1].Default
+  const selected =
+    profiles.find(([, profile]) => profile.Path === installDefault) || profiles.find(([, profile]) => profile.Default === '1') || profiles[0]
+  if (!selected) {
+    throw new Error('Firefox profile metadata does not contain a profile')
+  }
+  const [, profile] = selected
+  const profilePath = getProfilePath(firefoxDataDirectory, profile)
+  const cookieDatabasePath = join(profilePath, 'cookies.sqlite')
+  if (!existsSync(cookieDatabasePath)) {
+    throw new Error(`Firefox cookie database was not found for profile ${profile.Path}`)
+  }
+  return {
+    cookieDatabasePath,
+    directory: profile.Path,
+    name: profile.Name || profile.Path,
+  }
+}

--- a/packages/main-process/test/FirefoxCookieImport.test.ts
+++ b/packages/main-process/test/FirefoxCookieImport.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const temporaryDirectories: string[] = []
+const getCookieCount = jest.fn<(path: string) => number>()
+const readCookies = jest.fn<(path: string) => { readonly rows: readonly any[]; readonly version: number }>()
+
+jest.unstable_mockModule('electron', () => {
+  return {
+    session: {
+      fromPartition: jest.fn(),
+    },
+  }
+})
+
+jest.unstable_mockModule('../src/parts/FirefoxCookieDatabase/FirefoxCookieDatabase.ts', () => {
+  return {
+    getCookieCount,
+    readCookies,
+  }
+})
+
+const FirefoxCookieImport = await import('../src/parts/FirefoxCookieImport/FirefoxCookieImport.ts')
+
+interface CookieFixture {
+  readonly expiry?: number
+  readonly host?: string
+  readonly isHttpOnly?: number
+  readonly isSecure?: number
+  readonly name?: string
+  readonly originAttributes?: string
+  readonly path?: string
+  readonly sameSite?: number
+  readonly value?: string
+}
+
+const createTemporaryDirectory = (): string => {
+  const directory = mkdtempSync(join(tmpdir(), 'firefox-cookie-import-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+const createCookie = (fixture: CookieFixture = {}): any => {
+  return {
+    expiry: fixture.expiry ?? Date.now() + 3_600_000,
+    host: fixture.host || 'example.com',
+    isHttpOnly: fixture.isHttpOnly || 0,
+    isSecure: fixture.isSecure || 0,
+    name: fixture.name ?? 'session',
+    originAttributes: fixture.originAttributes || '',
+    path: fixture.path || '/',
+    sameSite: fixture.sameSite ?? 256,
+    value: fixture.value ?? 'secret',
+  }
+}
+
+const createFirefoxProfile = (): string => {
+  const firefoxDataDirectory = createTemporaryDirectory()
+  writeFileSync(
+    join(firefoxDataDirectory, 'profiles.ini'),
+    [
+      '[Profile0]',
+      'Name=Default profile',
+      'IsRelative=1',
+      'Path=Profiles/default',
+      'Default=1',
+      '',
+      '[Profile1]',
+      'Name=Work',
+      'IsRelative=1',
+      'Path=Profiles/work',
+      '',
+      '[InstallOld]',
+      'Default=Profiles/default',
+      '',
+      '[Install1234]',
+      'Default=Profiles/work',
+      'Locked=1',
+    ].join('\n'),
+  )
+  mkdirSync(join(firefoxDataDirectory, 'Profiles', 'work'), { recursive: true })
+  writeFileSync(join(firefoxDataDirectory, 'Profiles', 'work', 'cookies.sqlite'), '')
+  return firefoxDataDirectory
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { force: true, recursive: true })
+  }
+  temporaryDirectories.length = 0
+  jest.resetAllMocks()
+})
+
+test('getInfoFromDirectory selects the install default profile', () => {
+  const firefoxDataDirectory = createFirefoxProfile()
+  getCookieCount.mockReturnValue(2)
+
+  expect(FirefoxCookieImport.getInfoFromDirectory(firefoxDataDirectory)).toEqual({
+    cookieCount: 2,
+    profileDirectory: 'Profiles/work',
+    profileName: 'Work',
+  })
+  expect(getCookieCount).toHaveBeenCalledWith(join(firefoxDataDirectory, 'Profiles', 'work', 'cookies.sqlite'))
+})
+
+test('importFromDirectory imports regular cookies and skips expired and isolated cookies', async () => {
+  const firefoxDataDirectory = createFirefoxProfile()
+  readCookies.mockReturnValue({
+    rows: [
+      createCookie({
+        host: '.example.com',
+        isHttpOnly: 1,
+        isSecure: 1,
+        name: 'persistent',
+        path: '/account',
+        sameSite: 1,
+      }),
+      createCookie({
+        host: 'example.org',
+        name: 'host-only',
+      }),
+      createCookie({
+        expiry: Date.now() - 3_600_000,
+        name: 'expired',
+      }),
+      createCookie({
+        name: 'container',
+        originAttributes: '^userContextId=1',
+      }),
+    ],
+    version: 17,
+  })
+  const set = jest.fn<(...args: readonly any[]) => Promise<void>>().mockResolvedValue(undefined)
+  const flushStore = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+  await expect(
+    FirefoxCookieImport.importFromDirectory(firefoxDataDirectory, {
+      cookies: {
+        flushStore,
+        set,
+      } as any,
+    }),
+  ).resolves.toEqual({
+    failed: 0,
+    imported: 2,
+    skipped: 2,
+  })
+  expect(set).toHaveBeenNthCalledWith(1, {
+    domain: '.example.com',
+    expirationDate: expect.any(Number),
+    httpOnly: true,
+    name: 'persistent',
+    path: '/account',
+    sameSite: 'lax',
+    secure: true,
+    url: 'https://example.com/',
+    value: 'secret',
+  })
+  expect(set).toHaveBeenNthCalledWith(2, {
+    expirationDate: expect.any(Number),
+    httpOnly: false,
+    name: 'host-only',
+    path: '/',
+    sameSite: 'unspecified',
+    secure: false,
+    url: 'http://example.org/',
+    value: 'secret',
+  })
+  expect(flushStore).toHaveBeenCalledTimes(1)
+})
+
+test('importFromDirectory reports destination failures and still flushes', async () => {
+  const firefoxDataDirectory = createFirefoxProfile()
+  readCookies.mockReturnValue({
+    rows: [createCookie({ name: 'one' }), createCookie({ name: 'two' })],
+    version: 17,
+  })
+  const set = jest.fn<(...args: readonly any[]) => Promise<void>>().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('failed'))
+  const flushStore = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+  await expect(
+    FirefoxCookieImport.importFromDirectory(firefoxDataDirectory, {
+      cookies: {
+        flushStore,
+        set,
+      } as any,
+    }),
+  ).resolves.toEqual({
+    failed: 1,
+    imported: 1,
+    skipped: 0,
+  })
+  expect(flushStore).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Adds Firefox profile discovery and cookie import into the Simple Browser Electron session, including cookie conversion and focused coverage.