### PR TITLE
fix: preserve Firefox cookie expiry timestamps

### DIFF
--- a/packages/main-process/src/parts/FirefoxCookieConversion/FirefoxCookieConversion.ts
+++ b/packages/main-process/src/parts/FirefoxCookieConversion/FirefoxCookieConversion.ts
@@ -1,7 +1,5 @@
 import type { FirefoxCookieRow } from '../FirefoxCookieDatabase/FirefoxCookieDatabase.ts'
 
-const millisecondsExpirySchemaVersion = 16
-
 const getSameSite = (sameSite: number): Electron.CookiesSetDetails['sameSite'] => {
   switch (sameSite) {
     case 0:
@@ -15,15 +13,11 @@ const getSameSite = (sameSite: number): Electron.CookiesSetDetails['sameSite'] =
   }
 }
 
-const getExpirationDate = (expiry: number, databaseVersion: number): number => {
-  return databaseVersion >= millisecondsExpirySchemaVersion ? expiry / 1000 : expiry
-}
-
 const getUrlHost = (host: string): string => {
   return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
 }
 
-export const convert = (row: FirefoxCookieRow, databaseVersion: number, now: number = Date.now() / 1000): Electron.CookiesSetDetails | undefined => {
+export const convert = (row: FirefoxCookieRow, now: number = Date.now() / 1000): Electron.CookiesSetDetails | undefined => {
   if (!row.host || row.originAttributes) {
     return undefined
   }
@@ -31,7 +25,7 @@ export const convert = (row: FirefoxCookieRow, databaseVersion: number, now: num
   if (!host) {
     return undefined
   }
-  const expirationDate = getExpirationDate(row.expiry, databaseVersion)
+  const expirationDate = row.expiry
   if (!Number.isFinite(expirationDate) || expirationDate <= now) {
     return undefined
   }

--- a/packages/main-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ts
+++ b/packages/main-process/src/parts/FirefoxCookieImport/FirefoxCookieImport.ts
@@ -34,11 +34,11 @@ export const getInfo = (): FirefoxCookieImportInfo => {
 
 export const importFromDirectory = async (firefoxDataDirectory: string, session: CookieSession): Promise<FirefoxCookieImportResult> => {
   const profile = FirefoxCookieProfile.getActiveProfile(firefoxDataDirectory)
-  const { rows, version } = FirefoxCookieDatabase.readCookies(profile.cookieDatabasePath)
+  const { rows } = FirefoxCookieDatabase.readCookies(profile.cookieDatabasePath)
   const cookies: Electron.CookiesSetDetails[] = []
   let skipped = 0
   for (const row of rows) {
-    const cookie = FirefoxCookieConversion.convert(row, version)
+    const cookie = FirefoxCookieConversion.convert(row)
     if (cookie) {
       cookies.push(cookie)
     } else {

--- a/packages/main-process/test/FirefoxCookieImport.test.ts
+++ b/packages/main-process/test/FirefoxCookieImport.test.ts
@@ -107,6 +107,7 @@ test('getInfoFromDirectory selects the install default profile', () => {
 
 test('importFromDirectory imports regular cookies and skips expired and isolated cookies', async () => {
   const firefoxDataDirectory = createFirefoxProfile()
+  const expiredExpiry = Math.floor(Date.now() / 1000) - 3600
   readCookies.mockReturnValue({
     rows: [
       createCookie({
@@ -122,7 +123,7 @@ test('importFromDirectory imports regular cookies and skips expired and isolated
         name: 'host-only',
       }),
       createCookie({
-        expiry: Math.floor(Date.now() / 1000) - 3600,
+        expiry: expiredExpiry,
         name: 'expired',
       }),
       createCookie({

--- a/packages/main-process/test/FirefoxCookieImport.test.ts
+++ b/packages/main-process/test/FirefoxCookieImport.test.ts
@@ -44,7 +44,7 @@ const createTemporaryDirectory = (): string => {
 
 const createCookie = (fixture: CookieFixture = {}): any => {
   return {
-    expiry: fixture.expiry ?? Date.now() + 3_600_000,
+    expiry: fixture.expiry ?? Math.floor(Date.now() / 1000) + 3600,
     host: fixture.host || 'example.com',
     isHttpOnly: fixture.isHttpOnly || 0,
     isSecure: fixture.isSecure || 0,
@@ -122,7 +122,7 @@ test('importFromDirectory imports regular cookies and skips expired and isolated
         name: 'host-only',
       }),
       createCookie({
-        expiry: Date.now() - 3_600_000,
+        expiry: Math.floor(Date.now() / 1000) - 3600,
         name: 'expired',
       }),
       createCookie({


### PR DESCRIPTION
Preserves Firefox cookie expiry values as Unix seconds so current authenticated cookies are imported into the Simple Browser session instead of being treated as expired.