### PR TITLE
fix: support Chrome v11 cookie encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5941,6 +5941,21 @@
         "@cspell/cspell-types": "10.0.1"
       }
     },
+    "node_modules/dbus-native": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.1.tgz",
+      "integrity": "sha512-2Zdm+2eQuhmX08/Dyk3fltCqij5LGUwSx3Wj/ZN9IowlUw6eGfYZZXxkviUcN1iPOvWOQWUi74/nVnjZmg37vg==",
+      "license": "MIT",
+      "dependencies": {
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "dbus-native": "bin/dbus-native.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -11165,6 +11180,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scslre": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
@@ -12452,6 +12476,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -12604,6 +12650,7 @@
         "@lvce-editor/rpc": "^6.10.0",
         "@lvce-editor/rpc-registry": "^9.42.0",
         "@lvce-editor/verror": "^1.7.0",
+        "dbus-native": "^0.15.1",
         "electron-unhandled": "^5.0.0",
         "minimist": "^1.2.8"
       },

--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -59,6 +59,7 @@ const version = await getVersion()
 const packageJson = await readJson(join(root, 'packages', 'main-process', 'package.json'))
 
 delete packageJson.scripts
+const dbusNative = packageJson.dependencies['dbus-native']
 const electron = packageJson.devDependencies['electron']
 delete packageJson.devDependencies
 delete packageJson.prettier
@@ -67,6 +68,7 @@ delete packageJson.xo
 delete packageJson.directories
 delete packageJson.nodemonConfig
 packageJson.dependencies = {
+  'dbus-native': dbusNative,
   electron,
 }
 packageJson.version = version

--- a/packages/build/src/bundleJs.js
+++ b/packages/build/src/bundleJs.js
@@ -26,7 +26,7 @@ const options = {
     },
     inlineDynamicImports: true,
   },
-  external: ['electron', 'ws'],
+  external: ['dbus-native', 'electron', 'ws'],
   plugins: [
     babel({
       babelHelpers: 'bundled',

--- a/packages/main-process/package.json
+++ b/packages/main-process/package.json
@@ -53,6 +53,7 @@
     "@lvce-editor/rpc": "^6.10.0",
     "@lvce-editor/rpc-registry": "^9.42.0",
     "@lvce-editor/verror": "^1.7.0",
+    "dbus-native": "^0.15.1",
     "electron-unhandled": "^5.0.0",
     "minimist": "^1.2.8"
   },

--- a/packages/main-process/src/parts/ChromeCookieConversion/ChromeCookieConversion.ts
+++ b/packages/main-process/src/parts/ChromeCookieConversion/ChromeCookieConversion.ts
@@ -22,14 +22,19 @@ const getExpirationDate = (expiresUtc: string): number => {
   return Number(chromeMicroseconds - chromeEpochOffsetMicroseconds) / Number(microsecondsPerSecond)
 }
 
-const getValue = (row: ChromeCookieRow, databaseVersion: number): string => {
+const getValue = (row: ChromeCookieRow, databaseVersion: number, chromeSafeStoragePassword?: string): string => {
   if (row.value) {
     return row.value
   }
-  return ChromeCookieDecrypt.decrypt(row.hostKey, row.encryptedValue, databaseVersion)
+  return ChromeCookieDecrypt.decrypt(row.hostKey, row.encryptedValue, databaseVersion, chromeSafeStoragePassword)
 }
 
-export const convert = (row: ChromeCookieRow, databaseVersion: number, now: number = Date.now() / 1000): Electron.CookiesSetDetails | undefined => {
+export const convert = (
+  row: ChromeCookieRow,
+  databaseVersion: number,
+  chromeSafeStoragePassword?: string,
+  now: number = Date.now() / 1000,
+): Electron.CookiesSetDetails | undefined => {
   if (!row.hostKey || row.topFrameSiteKey) {
     return undefined
   }
@@ -45,7 +50,7 @@ export const convert = (row: ChromeCookieRow, databaseVersion: number, now: numb
     sameSite: getSameSite(row.sameSite),
     secure,
     url: `${secure ? 'https' : 'http'}://${host}/`,
-    value: getValue(row, databaseVersion),
+    value: getValue(row, databaseVersion, chromeSafeStoragePassword),
   }
   if (row.hostKey.startsWith('.')) {
     details.domain = row.hostKey

--- a/packages/main-process/src/parts/ChromeCookieDecrypt/ChromeCookieDecrypt.ts
+++ b/packages/main-process/src/parts/ChromeCookieDecrypt/ChromeCookieDecrypt.ts
@@ -1,6 +1,7 @@
 import { createDecipheriv, createHash, pbkdf2Sync } from 'node:crypto'
 
 const chromeV10Prefix = Buffer.from('v10')
+const chromeV11Prefix = Buffer.from('v11')
 const chromeV10Key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1')
 const chromeV10Iv = Buffer.alloc(16, 0x20)
 const domainHashLength = 32
@@ -12,13 +13,26 @@ export class UnsupportedChromeCookieEncryptionError extends Error {
   }
 }
 
-export const decrypt = (hostKey: string, encryptedValue: Uint8Array, databaseVersion: number): string => {
+export const isV11 = (encryptedValue: Uint8Array): boolean => {
+  return Buffer.from(encryptedValue).subarray(0, chromeV11Prefix.length).equals(chromeV11Prefix)
+}
+
+export const decrypt = (hostKey: string, encryptedValue: Uint8Array, databaseVersion: number, chromeSafeStoragePassword?: string): string => {
   const buffer = Buffer.from(encryptedValue)
-  if (buffer.length <= chromeV10Prefix.length || !buffer.subarray(0, chromeV10Prefix.length).equals(chromeV10Prefix)) {
+  if (buffer.length <= chromeV10Prefix.length) {
     throw new UnsupportedChromeCookieEncryptionError()
   }
-  const decipher = createDecipheriv('aes-128-cbc', chromeV10Key, chromeV10Iv)
-  const plaintext = Buffer.concat([decipher.update(buffer.subarray(chromeV10Prefix.length)), decipher.final()])
+  const prefix = buffer.subarray(0, chromeV10Prefix.length)
+  let key: Buffer
+  if (prefix.equals(chromeV10Prefix)) {
+    key = chromeV10Key
+  } else if (prefix.equals(chromeV11Prefix) && chromeSafeStoragePassword !== undefined) {
+    key = pbkdf2Sync(chromeSafeStoragePassword, 'saltysalt', 1, 16, 'sha1')
+  } else {
+    throw new UnsupportedChromeCookieEncryptionError()
+  }
+  const decipher = createDecipheriv('aes-128-cbc', key, chromeV10Iv)
+  const plaintext = Buffer.concat([decipher.update(buffer.subarray(prefix.length)), decipher.final()])
   if (databaseVersion < 24) {
     return plaintext.toString('utf8')
   }

--- a/packages/main-process/src/parts/ChromeCookieImport/ChromeCookieImport.ts
+++ b/packages/main-process/src/parts/ChromeCookieImport/ChromeCookieImport.ts
@@ -1,7 +1,8 @@
 import type { Session } from 'electron'
 import * as ChromeCookieConversion from '../ChromeCookieConversion/ChromeCookieConversion.ts'
 import * as ChromeCookieDatabase from '../ChromeCookieDatabase/ChromeCookieDatabase.ts'
-import { UnsupportedChromeCookieEncryptionError } from '../ChromeCookieDecrypt/ChromeCookieDecrypt.ts'
+import { isV11, UnsupportedChromeCookieEncryptionError } from '../ChromeCookieDecrypt/ChromeCookieDecrypt.ts'
+import * as ChromeCookieKeyring from '../ChromeCookieKeyring/ChromeCookieKeyring.ts'
 import * as ChromeCookieProfile from '../ChromeCookieProfile/ChromeCookieProfile.ts'
 import * as ElectronSessionForBrowserView from '../ElectronSessionForBrowserView/ElectronSessionForBrowserView.ts'
 
@@ -43,12 +44,14 @@ export const getInfo = (): ChromeCookieImportInfo => {
 export const importFromDirectory = async (chromeDataDirectory: string, session: CookieSession): Promise<ChromeCookieImportResult> => {
   const profile = ChromeCookieProfile.getActiveProfile(chromeDataDirectory)
   const { rows, version } = ChromeCookieDatabase.readCookies(profile.cookieDatabasePath)
+  const requiresChromeSafeStoragePassword = rows.some((row) => !row.value && isV11(row.encryptedValue))
+  const chromeSafeStoragePassword = requiresChromeSafeStoragePassword ? await ChromeCookieKeyring.getChromeSafeStoragePassword() : undefined
   const cookies: Electron.CookiesSetDetails[] = []
   let skipped = 0
   let unsupportedEncryption = 0
   for (const row of rows) {
     try {
-      const cookie = ChromeCookieConversion.convert(row, version)
+      const cookie = ChromeCookieConversion.convert(row, version, chromeSafeStoragePassword)
       if (cookie) {
         cookies.push(cookie)
       } else {

--- a/packages/main-process/src/parts/ChromeCookieKeyring/ChromeCookieKeyring.ts
+++ b/packages/main-process/src/parts/ChromeCookieKeyring/ChromeCookieKeyring.ts
@@ -1,0 +1,88 @@
+import dbus, { Variant, type DBusInterface, type MessageBus } from 'dbus-native'
+
+const secretServiceName = 'org.freedesktop.secrets'
+const secretServicePath = '/org/freedesktop/secrets'
+const secretServiceInterface = 'org.freedesktop.Secret.Service'
+const secretCollectionInterface = 'org.freedesktop.Secret.Collection'
+const secretItemInterface = 'org.freedesktop.Secret.Item'
+const propertiesInterface = 'org.freedesktop.DBus.Properties'
+const defaultCollectionPath = '/org/freedesktop/secrets/aliases/default'
+const chromeSafeStorageLabel = 'Chrome Safe Storage'
+
+interface SecretService extends DBusInterface {
+  GetSecrets(items: readonly string[], session: string): PromiseLike<Readonly<Record<string, readonly [string, Uint8Array, Uint8Array, string]>>>
+  OpenSession(algorithm: string, input: Variant<string>): PromiseLike<readonly [unknown, string]>
+  SearchItems(attributes: Readonly<Record<string, string>>): PromiseLike<readonly [readonly string[], readonly string[]]>
+  Unlock(items: readonly string[]): PromiseLike<readonly [readonly string[], string]>
+}
+
+interface Properties extends DBusInterface {
+  Get(interfaceName: string, propertyName: string): PromiseLike<unknown>
+}
+
+const getProperties = async (bus: MessageBus, path: string): Promise<Properties> => {
+  return bus.getService(secretServiceName).getInterface<Properties>(path, propertiesInterface)
+}
+
+const findChromeSafeStorageItem = async (bus: MessageBus, service: SecretService): Promise<string> => {
+  const [unlocked, locked] = await service.SearchItems({ application: 'chrome' })
+  const matchingItems = [...unlocked, ...locked]
+  if (matchingItems.length > 0) {
+    return matchingItems[0]
+  }
+
+  const collectionProperties = await getProperties(bus, defaultCollectionPath)
+  const items = (await collectionProperties.Get(secretCollectionInterface, 'Items')) as readonly string[]
+  for (const item of items) {
+    const itemProperties = await getProperties(bus, item)
+    const label = await itemProperties.Get(secretItemInterface, 'Label')
+    if (label === chromeSafeStorageLabel) {
+      return item
+    }
+  }
+  throw new Error('Chrome Safe Storage password was not found in the Linux keyring')
+}
+
+const unlockItem = async (service: SecretService, item: string): Promise<void> => {
+  const [unlocked, prompt] = await service.Unlock([item])
+  if (unlocked.includes(item)) {
+    return
+  }
+  if (prompt !== '/') {
+    throw new Error('Chrome Safe Storage is locked; unlock the desktop keyring and try again')
+  }
+  throw new Error('Chrome Safe Storage could not be unlocked')
+}
+
+const readPassword = async (bus: MessageBus): Promise<string> => {
+  const service = await bus.getService(secretServiceName).getInterface<SecretService>(secretServicePath, secretServiceInterface)
+  const [, sessionPath] = await service.OpenSession('plain', new Variant('s', ''))
+  const item = await findChromeSafeStorageItem(bus, service)
+  let secrets: Readonly<Record<string, readonly [string, Uint8Array, Uint8Array, string]>>
+  try {
+    secrets = await service.GetSecrets([item], sessionPath)
+  } catch {
+    await unlockItem(service, item)
+    secrets = await service.GetSecrets([item], sessionPath)
+  }
+  const secret = secrets[item]
+  if (!secret) {
+    throw new Error('Chrome Safe Storage password was not returned by the Linux keyring')
+  }
+  return Buffer.from(secret[2]).toString('utf8')
+}
+
+const getErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export const getChromeSafeStoragePassword = async (): Promise<string> => {
+  const bus = dbus.sessionBus({ timeout: 5000 })
+  try {
+    return await readPassword(bus)
+  } catch (error) {
+    throw new Error(`Failed to read Chrome Safe Storage password: ${getErrorMessage(error)}`)
+  } finally {
+    await bus.close()
+  }
+}

--- a/packages/main-process/test/ChromeCookieImport.test.ts
+++ b/packages/main-process/test/ChromeCookieImport.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 const temporaryDirectories: string[] = []
 const chromeEpochOffsetMicroseconds = 11_644_473_600_000_000n
 const getCookieCount = jest.fn<(path: string) => number>()
+const getChromeSafeStoragePassword = jest.fn<() => Promise<string>>()
 const readCookies = jest.fn<(path: string) => { readonly rows: readonly any[]; readonly version: number }>()
 
 jest.unstable_mockModule('electron', () => {
@@ -21,6 +22,12 @@ jest.unstable_mockModule('../src/parts/ChromeCookieDatabase/ChromeCookieDatabase
   return {
     getCookieCount,
     readCookies,
+  }
+})
+
+jest.unstable_mockModule('../src/parts/ChromeCookieKeyring/ChromeCookieKeyring.ts', () => {
+  return {
+    getChromeSafeStoragePassword,
   }
 })
 
@@ -47,12 +54,12 @@ const createTemporaryDirectory = (): string => {
   return directory
 }
 
-const encryptCookie = (hostKey: string, value: string): Buffer => {
-  const key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1')
+const encryptCookie = (hostKey: string, value: string, format: 'v10' | 'v11' = 'v10', password: string = 'peanuts'): Buffer => {
+  const key = pbkdf2Sync(password, 'saltysalt', 1, 16, 'sha1')
   const iv = Buffer.alloc(16, 0x20)
-  const cipher = createCipheriv('aes-128-cbc', key, iv) // eslint-disable-line sonarjs/encryption-secure-mode -- reproduces Chrome's v10 cookie format
+  const cipher = createCipheriv('aes-128-cbc', key, iv) // eslint-disable-line sonarjs/encryption-secure-mode -- reproduces Chrome's Linux cookie format
   const plaintext = Buffer.concat([createHash('sha256').update(hostKey).digest(), Buffer.from(value)])
-  return Buffer.concat([Buffer.from('v10'), cipher.update(plaintext), cipher.final()])
+  return Buffer.concat([Buffer.from(format), cipher.update(plaintext), cipher.final()])
 }
 
 const getChromeTimestamp = (unixSeconds: number): string => {
@@ -152,6 +159,56 @@ test('decrypt validates the version 24 domain hash', () => {
   expect(() => ChromeCookieDecrypt.decrypt('.other.example.com', encryptedValue, 24)).toThrow('Chrome cookie domain integrity check failed')
 })
 
+test('decrypt supports Chrome v11 cookies using the Safe Storage password', () => {
+  const encryptedValue = encryptCookie('.example.com', 'secret', 'v11', 'safe-storage-password')
+
+  expect(ChromeCookieDecrypt.decrypt('.example.com', encryptedValue, 24, 'safe-storage-password')).toBe('secret')
+})
+
+test('importFromDirectory imports Chrome v11 cookies using the Safe Storage password', async () => {
+  const chromeDataDirectory = createChromeProfile(
+    {
+      Default: {
+        active_time: 1,
+        name: 'Default profile',
+      },
+    },
+    'Default',
+  )
+  getChromeSafeStoragePassword.mockResolvedValue('safe-storage-password')
+  readCookies.mockReturnValue({
+    rows: [
+      createCookie({
+        encryptedValue: encryptCookie('.example.com', 'authenticated', 'v11', 'safe-storage-password'),
+        hostKey: '.example.com',
+      }),
+    ],
+    version: 24,
+  })
+  const set = jest.fn<(...args: readonly any[]) => Promise<void>>().mockResolvedValue(undefined)
+  const flushStore = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+  await expect(
+    ChromeCookieImport.importFromDirectory(chromeDataDirectory, {
+      cookies: {
+        flushStore,
+        set,
+      } as any,
+    }),
+  ).resolves.toEqual({
+    failed: 0,
+    imported: 1,
+    skipped: 0,
+  })
+  expect(getChromeSafeStoragePassword).toHaveBeenCalledTimes(1)
+  expect(set).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'session',
+      value: 'authenticated',
+    }),
+  )
+})
+
 test('importFromDirectory imports eligible cookies and skips unsupported cookies', async () => {
   const now = Date.now() / 1000
   const chromeDataDirectory = createChromeProfile(
@@ -190,7 +247,7 @@ test('importFromDirectory imports eligible cookies and skips unsupported cookies
         topFrameSiteKey: 'https://top.example',
       }),
       createCookie({
-        encryptedValue: Buffer.from('v11unsupported'),
+        encryptedValue: Buffer.from('v20unsupported'),
         name: 'unsupported',
       }),
     ],
@@ -279,7 +336,7 @@ test('importFromDirectory fails closed when every encrypted cookie is unsupporte
   readCookies.mockReturnValue({
     rows: [
       createCookie({
-        encryptedValue: Buffer.from('v11unsupported'),
+        encryptedValue: Buffer.from('v20unsupported'),
       }),
     ],
     version: 24,

--- a/packages/main-process/test/ChromeCookieKeyring.test.ts
+++ b/packages/main-process/test/ChromeCookieKeyring.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+
+const sessionBus = jest.fn<() => any>()
+
+class Variant {
+  constructor(
+    public readonly signature: string,
+    public readonly value: unknown,
+  ) {}
+}
+
+jest.unstable_mockModule('dbus-native', () => {
+  return {
+    default: {
+      sessionBus,
+    },
+    Variant,
+  }
+})
+
+const ChromeCookieKeyring = await import('../src/parts/ChromeCookieKeyring/ChromeCookieKeyring.ts')
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+test('reads the Chrome Safe Storage password from Secret Service', async () => {
+  const service = {
+    GetSecrets: jest
+      .fn<(items: readonly string[], session: string) => Promise<Readonly<Record<string, readonly [string, Uint8Array, Uint8Array, string]>>>>()
+      .mockResolvedValue({
+      '/item/chrome': ['/session/1', Buffer.alloc(0), Buffer.from('safe-storage-password'), 'text/plain'],
+    }),
+    OpenSession: jest.fn<(algorithm: string, input: unknown) => Promise<readonly [string, string]>>().mockResolvedValue(['', '/session/1']),
+    SearchItems: jest
+      .fn<(attributes: Readonly<Record<string, string>>) => Promise<readonly [readonly string[], readonly string[]]>>()
+      .mockResolvedValue([['/item/chrome'], []]),
+    Unlock: jest.fn(),
+  }
+  const close = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+  const getInterface = jest.fn<() => Promise<unknown>>().mockResolvedValue(service)
+  sessionBus.mockReturnValue({
+    close,
+    getService: jest.fn().mockReturnValue({ getInterface }),
+  })
+
+  await expect(ChromeCookieKeyring.getChromeSafeStoragePassword()).resolves.toBe('safe-storage-password')
+  expect(service.OpenSession).toHaveBeenCalledWith('plain', expect.objectContaining({ signature: 's', value: '' }))
+  expect(service.SearchItems).toHaveBeenCalledWith({ application: 'chrome' })
+  expect(service.GetSecrets).toHaveBeenCalledWith(['/item/chrome'], '/session/1')
+  expect(service.Unlock).not.toHaveBeenCalled()
+  expect(close).toHaveBeenCalledTimes(1)
+})
+
+test('reports when Chrome Safe Storage is locked and always closes the bus', async () => {
+  const service = {
+    GetSecrets: jest
+      .fn<(items: readonly string[], session: string) => Promise<Readonly<Record<string, readonly [string, Uint8Array, Uint8Array, string]>>>>()
+      .mockRejectedValue(new Error('locked')),
+    OpenSession: jest.fn<() => Promise<readonly [string, string]>>().mockResolvedValue(['', '/session/1']),
+    SearchItems: jest.fn<() => Promise<readonly [readonly string[], readonly string[]]>>().mockResolvedValue([[], ['/item/chrome']]),
+    Unlock: jest.fn<() => Promise<readonly [readonly string[], string]>>().mockResolvedValue([[], '/prompt/1']),
+  }
+  const close = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+  sessionBus.mockReturnValue({
+    close,
+    getService: jest.fn().mockReturnValue({
+      getInterface: jest.fn<() => Promise<unknown>>().mockResolvedValue(service),
+    }),
+  })
+
+  await expect(ChromeCookieKeyring.getChromeSafeStoragePassword()).rejects.toThrow(
+    'Failed to read Chrome Safe Storage password: Chrome Safe Storage is locked; unlock the desktop keyring and try again',
+  )
+  expect(close).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Support Linux Chrome v11 cookies by reading the existing Chrome Safe Storage secret through the desktop Secret Service and using Chromium's v11 key derivation. Keep v10 imports unchanged, ship the D-Bus client as a runtime dependency, and cover decryption, import, and keyring failure behavior.