### PR TITLE
fix: enable Chromium sandbox by default

### DIFF
--- a/packages/main-process/src/parts/CommandLineSwitches/CommandLineSwitches.ts
+++ b/packages/main-process/src/parts/CommandLineSwitches/CommandLineSwitches.ts
@@ -8,7 +8,8 @@ export const enable = (parsedCliArgs) => {
   if (parsedCliArgs.sandbox) {
     Sandbox.enableSandbox()
   } else {
-    // see https://github.com/microsoft/vscode/issues/151187#issuecomment-1221475319
+    // The GPU sandbox must also be disabled when Chromium's sandbox was explicitly disabled.
+    // See https://github.com/microsoft/vscode/issues/151187#issuecomment-1221475319
     if (Platform.isLinux) {
       // @ts-ignore
       ElectronApp.appendCommandLineSwitch('--disable-gpu-sandbox')

--- a/packages/main-process/src/parts/ParseCliArgs/ParseCliArgs.ts
+++ b/packages/main-process/src/parts/ParseCliArgs/ParseCliArgs.ts
@@ -15,7 +15,7 @@ export const parseCliArgs = (argv) => {
       CliCommandType.SandBox,
     ],
     default: {
-      sandbox: false,
+      sandbox: true,
     },
     string: [CliCommandType.Prompt],
   }

--- a/packages/main-process/test/CommandLineSwitches.test.ts
+++ b/packages/main-process/test/CommandLineSwitches.test.ts
@@ -13,6 +13,12 @@ jest.unstable_mockModule('electron', () => {
   }
 })
 
+jest.unstable_mockModule('../src/parts/Platform/Platform.ts', () => {
+  return {
+    isLinux: true,
+  }
+})
+
 const CommandLineSwitches = await import('../src/parts/CommandLineSwitches/CommandLineSwitches.ts')
 const ParseCliArgs = await import('../src/parts/ParseCliArgs/ParseCliArgs.ts')
 

--- a/packages/main-process/test/CommandLineSwitches.test.ts
+++ b/packages/main-process/test/CommandLineSwitches.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+const electronApp = {
+  commandLine: {
+    appendSwitch: jest.fn(),
+  },
+  enableSandbox: jest.fn(),
+}
+
+jest.unstable_mockModule('electron', () => {
+  return {
+    app: electronApp,
+  }
+})
+
+const CommandLineSwitches = await import('../src/parts/CommandLineSwitches/CommandLineSwitches.ts')
+const ParseCliArgs = await import('../src/parts/ParseCliArgs/ParseCliArgs.ts')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('enables the Chromium sandbox by default', () => {
+  const parsedCliArgs = ParseCliArgs.parseCliArgs(['/usr/lib/lvce/lvce', '/test/'])
+
+  CommandLineSwitches.enable(parsedCliArgs)
+
+  expect(electronApp.enableSandbox).toHaveBeenCalledTimes(1)
+  expect(electronApp.commandLine.appendSwitch).toHaveBeenCalledTimes(1)
+  expect(electronApp.commandLine.appendSwitch).toHaveBeenCalledWith('lang', 'en')
+})
+
+test('disables the GPU sandbox only when no-sandbox is requested', () => {
+  const parsedCliArgs = ParseCliArgs.parseCliArgs(['/usr/lib/lvce/lvce', '--no-sandbox', '/test/'])
+
+  CommandLineSwitches.enable(parsedCliArgs)
+
+  expect(electronApp.enableSandbox).not.toHaveBeenCalled()
+  expect(electronApp.commandLine.appendSwitch).toHaveBeenCalledTimes(2)
+  expect(electronApp.commandLine.appendSwitch).toHaveBeenCalledWith('--disable-gpu-sandbox', undefined)
+  expect(electronApp.commandLine.appendSwitch).toHaveBeenCalledWith('lang', 'en')
+})

--- a/packages/main-process/test/ParseCliArgs.test.ts
+++ b/packages/main-process/test/ParseCliArgs.test.ts
@@ -6,7 +6,7 @@ test('parseCliArgs', () => {
     _: ['/test/'],
     'built-in-self-test': false,
     help: false,
-    sandbox: false,
+    sandbox: true,
     v: false,
     version: false,
     wait: false,
@@ -18,6 +18,13 @@ test('parseCliArgs - prompt', () => {
   expect(ParseCliArgs.parseCliArgs(['/usr/lib/lvce-oss/lvce-oss', '--prompt', 'Fix the tests'])).toMatchObject({
     _: [],
     prompt: 'Fix the tests',
+  })
+})
+
+test('parseCliArgs - no sandbox', () => {
+  expect(ParseCliArgs.parseCliArgs(['/usr/lib/lvce-oss/lvce-oss', '--no-sandbox', '/test/'])).toMatchObject({
+    _: ['/test/'],
+    sandbox: false,
   })
 })
 


### PR DESCRIPTION
Enables Chromium's sandbox during normal launches while preserving explicit --no-sandbox behavior. This avoids disabling the Linux GPU sandbox by default and reduces LVCE's idle GPU-process RSS.