### PR TITLE
feature: add web contents zoom keybindings

### DIFF
--- a/packages/main-process/src/parts/ElectronBrowserViewEventListenerBeforeInput/ElectronBrowserViewEventListenerBeforeInput.ts
+++ b/packages/main-process/src/parts/ElectronBrowserViewEventListenerBeforeInput/ElectronBrowserViewEventListenerBeforeInput.ts
@@ -2,6 +2,7 @@ import * as ElectronInputType from '../ElectronInputType/ElectronInputType.ts'
 import * as ElectronWebContentsEventType from '../ElectronWebContentsEventType/ElectronWebContentsEventType.ts'
 import * as ElectronWebContentsViewState from '../ElectronWebContentsViewState/ElectronWebContentsViewState.ts'
 import * as GetKeyBindingIdentifier from '../GetKeyBindingIdentifier/GetKeyBindingIdentifier.ts'
+import * as HandleWebContentsViewZoomKeyBinding from '../HandleWebContentsViewZoomKeyBinding/HandleWebContentsViewZoomKeyBinding.ts'
 
 export const key = 'before-input'
 
@@ -13,8 +14,16 @@ export const detach = (webContents, listener): void => {
   webContents.off(ElectronWebContentsEventType.BeforeInputEvent, listener)
 }
 
-export const handler = (event, input): any => {
+export const handler = (event, input, webContentsId): any => {
   if (input.type !== ElectronInputType.KeyDown) {
+    return {
+      messages: [],
+      result: undefined,
+    }
+  }
+  const didZoom = HandleWebContentsViewZoomKeyBinding.handleWebContentsViewZoomKeyBinding(webContentsId, input)
+  if (didZoom) {
+    event.preventDefault()
     return {
       messages: [],
       result: undefined,

--- a/packages/main-process/src/parts/HandleWebContentsViewZoomKeyBinding/HandleWebContentsViewZoomKeyBinding.ts
+++ b/packages/main-process/src/parts/HandleWebContentsViewZoomKeyBinding/HandleWebContentsViewZoomKeyBinding.ts
@@ -1,0 +1,34 @@
+import * as ElectronWebContentsViewState from '../ElectronWebContentsViewState/ElectronWebContentsViewState.ts'
+
+const MaxZoomLevel = 3
+const MinZoomLevel = -3
+const ZoomDelta = 0.2
+
+const getZoomDelta = (input): number => {
+  if (!input.control || input.alt || input.meta) {
+    return 0
+  }
+  if (input.key === '+' || input.key === '=') {
+    return ZoomDelta
+  }
+  if (input.key === '-') {
+    return -ZoomDelta
+  }
+  return 0
+}
+
+export const handleWebContentsViewZoomKeyBinding = (webContentsId: number, input): boolean => {
+  const delta = getZoomDelta(input)
+  if (delta === 0) {
+    return false
+  }
+  const state = ElectronWebContentsViewState.get(webContentsId)
+  if (!state) {
+    return false
+  }
+  const { webContents } = state.view
+  const currentZoomLevel = webContents.getZoomLevel()
+  const newZoomLevel = Math.max(MinZoomLevel, Math.min(MaxZoomLevel, currentZoomLevel + delta))
+  webContents.setZoomLevel(newZoomLevel)
+  return true
+}

--- a/packages/main-process/test/ElectronBrowserViewEventListenerBeforeInput.test.ts
+++ b/packages/main-process/test/ElectronBrowserViewEventListenerBeforeInput.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as ElectronBrowserViewEventListenerBeforeInput from '../src/parts/ElectronBrowserViewEventListenerBeforeInput/ElectronBrowserViewEventListenerBeforeInput.ts'
+import * as ElectronWebContentsViewState from '../src/parts/ElectronWebContentsViewState/ElectronWebContentsViewState.ts'
+
+const webContentsId = 12
+
+const createInput = (overrides = {}) => {
+  return {
+    alt: false,
+    control: true,
+    key: '+',
+    meta: false,
+    shift: true,
+    type: 'keyDown',
+    ...overrides,
+  }
+}
+
+const createWebContents = (zoomLevel = 0) => {
+  return {
+    getZoomLevel: jest.fn(() => zoomLevel),
+    setZoomLevel: jest.fn(),
+  }
+}
+
+beforeEach(() => {
+  ElectronWebContentsViewState.remove(webContentsId)
+  ElectronWebContentsViewState.setFallthroughKeyBindings([])
+})
+
+test.each([
+  ['+', true],
+  ['=', false],
+])('zooms in for Ctrl+%s', (key, shift) => {
+  const preventDefault = jest.fn()
+  const webContents = createWebContents()
+  ElectronWebContentsViewState.add(webContentsId, {}, { webContents })
+
+  const result = ElectronBrowserViewEventListenerBeforeInput.handler({ preventDefault }, createInput({ key, shift }), webContentsId)
+
+  expect(result).toEqual({ messages: [], result: undefined })
+  expect(preventDefault).toHaveBeenCalledTimes(1)
+  expect(webContents.getZoomLevel).toHaveBeenCalledTimes(1)
+  expect(webContents.setZoomLevel).toHaveBeenCalledTimes(1)
+  expect(webContents.setZoomLevel).toHaveBeenCalledWith(0.2)
+})
+
+test('zooms out for Ctrl+-', () => {
+  const preventDefault = jest.fn()
+  const webContents = createWebContents(0.4)
+  ElectronWebContentsViewState.add(webContentsId, {}, { webContents })
+
+  const result = ElectronBrowserViewEventListenerBeforeInput.handler(
+    { preventDefault },
+    createInput({ key: '-', shift: false }),
+    webContentsId,
+  )
+
+  expect(result).toEqual({ messages: [], result: undefined })
+  expect(preventDefault).toHaveBeenCalledTimes(1)
+  expect(webContents.getZoomLevel).toHaveBeenCalledTimes(1)
+  expect(webContents.setZoomLevel).toHaveBeenCalledTimes(1)
+  expect(webContents.setZoomLevel).toHaveBeenCalledWith(0.2)
+})
+
+test('does not zoom without Ctrl', () => {
+  const preventDefault = jest.fn()
+  const webContents = createWebContents()
+  ElectronWebContentsViewState.add(webContentsId, {}, { webContents })
+
+  const result = ElectronBrowserViewEventListenerBeforeInput.handler(
+    { preventDefault },
+    createInput({ control: false, key: '-', shift: false }),
+    webContentsId,
+  )
+
+  expect(result).toEqual({ messages: [], result: undefined })
+  expect(preventDefault).not.toHaveBeenCalled()
+  expect(webContents.getZoomLevel).not.toHaveBeenCalled()
+  expect(webContents.setZoomLevel).not.toHaveBeenCalled()
+})
+
+test('does not zoom for key-up events', () => {
+  const preventDefault = jest.fn()
+  const webContents = createWebContents()
+  ElectronWebContentsViewState.add(webContentsId, {}, { webContents })
+
+  const result = ElectronBrowserViewEventListenerBeforeInput.handler(
+    { preventDefault },
+    createInput({ type: 'keyUp' }),
+    webContentsId,
+  )
+
+  expect(result).toEqual({ messages: [], result: undefined })
+  expect(preventDefault).not.toHaveBeenCalled()
+  expect(webContents.getZoomLevel).not.toHaveBeenCalled()
+  expect(webContents.setZoomLevel).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Add Ctrl++/Ctrl+= and Ctrl+- zoom handling for focused WebContentsViews.

This makes Simple Browser zoom its embedded page while that page has focus.