### PR TITLE
fix: serve app urls with query parameters

### DIFF
--- a/packages/main-process/src/parts/GetRelativePath/GetRelativePath.ts
+++ b/packages/main-process/src/parts/GetRelativePath/GetRelativePath.ts
@@ -2,5 +2,6 @@ import { scheme } from '../Platform/Platform.ts'
 
 export const getRelativePath = (url: string) => {
   const relative = url.slice(scheme.length + 4)
-  return relative
+  const queryIndex = relative.indexOf('?')
+  return queryIndex === -1 ? relative : relative.slice(0, queryIndex)
 }

--- a/packages/main-process/test/GetRelativePath.test.ts
+++ b/packages/main-process/test/GetRelativePath.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@jest/globals'
+import { getRelativePath } from '../src/parts/GetRelativePath/GetRelativePath.ts'
+
+test('returns the relative path', () => {
+  expect(getRelativePath('lvce-oss://-/static/main.js')).toBe('/static/main.js')
+})
+
+test('removes query parameters from the root path', () => {
+  expect(getRelativePath('lvce-oss://-/?workspace=file%3A%2F%2F%2Ftmp&openUri=file%3A%2F%2F%2Ftmp%2Fexample.txt')).toBe('/')
+})
+
+test('removes query parameters from a resource path', () => {
+  expect(getRelativePath('lvce-oss://-/static/main.js?v=1')).toBe('/static/main.js')
+})


### PR DESCRIPTION
## Summary

- strip query parameters before looking up packaged static files
- add coverage for root and resource URLs with query parameters
- allow packaged CLI file URLs (`workspace` plus `openUri`) to load the workbench

## Validation

- `npm test --workspace packages/main-process -- GetRelativePath.test.ts --runInBand`
- `npm run type-check`
- `npx eslint packages/main-process/src/parts/GetRelativePath/GetRelativePath.ts packages/main-process/test/GetRelativePath.test.ts`

Follow-up found while validating lvce-editor v0.95.14 after lvce-editor/lvce-editor#13360.