### PR TITLE
fix: preserve editor focus during preview navigation

### DIFF
--- a/packages/main-process/src/parts/ElectronWebContentsEventType/ElectronWebContentsEventType.ts
+++ b/packages/main-process/src/parts/ElectronWebContentsEventType/ElectronWebContentsEventType.ts
@@ -1,5 +1,6 @@
 export const ContextMenu = 'context-menu'
 export const WillNavigate = 'will-navigate'
+export const DidStartNavigation = 'did-start-navigation'
 export const DidNavigate = 'did-navigate'
 export const PageTitleUpdated = 'page-title-updated'
 export const Destroyed = 'destroyed'

--- a/packages/main-process/src/parts/ElectronWebContentsView/ElectronWebContentsView.ts
+++ b/packages/main-process/src/parts/ElectronWebContentsView/ElectronWebContentsView.ts
@@ -4,6 +4,7 @@ import * as Assert from '../Assert/Assert.ts'
 import * as ElectronBrowserViewEventListeners from '../ElectronBrowserViewEventListeners/ElectronBrowserViewEventListeners.ts'
 import * as ElectronSessionForBrowserView from '../ElectronSessionForBrowserView/ElectronSessionForBrowserView.ts'
 import * as ElectronWebContentsViewAuthenticationState from '../ElectronWebContentsViewAuthenticationState/ElectronWebContentsViewAuthenticationState.ts'
+import * as ElectronWebContentsViewNavigationFocus from '../ElectronWebContentsViewNavigationFocus/ElectronWebContentsViewNavigationFocus.ts'
 import * as ElectronWebContentsViewState from '../ElectronWebContentsViewState/ElectronWebContentsViewState.ts'
 import * as EmbedsProcess from '../EmbedsProcess/EmbedsProcess.ts'
 
@@ -25,9 +26,11 @@ export const createWebContentsView = async () => {
 export const attachEventListeners = (webContentsId) => {
   Assert.number(webContentsId)
   const webContents = Electron.webContents.fromId(webContentsId)
-  if (!webContents) {
+  const state = ElectronWebContentsViewState.get(webContentsId)
+  if (!webContents || !state) {
     return
   }
+  ElectronWebContentsViewNavigationFocus.attach(webContents, state.browserWindow.webContents)
   const values = Object.values(ElectronBrowserViewEventListeners)
   for (const value of values) {
     const wrappedListener = (...args) => {

--- a/packages/main-process/src/parts/ElectronWebContentsViewNavigationFocus/ElectronWebContentsViewNavigationFocus.ts
+++ b/packages/main-process/src/parts/ElectronWebContentsViewNavigationFocus/ElectronWebContentsViewNavigationFocus.ts
@@ -1,0 +1,21 @@
+import type { WebContents } from 'electron'
+import * as ElectronWebContentsEventType from '../ElectronWebContentsEventType/ElectronWebContentsEventType.ts'
+
+export const attach = (webContents: WebContents, parentWebContents: WebContents): void => {
+  let shouldRestoreParentFocus = false
+
+  webContents.on(ElectronWebContentsEventType.DidStartNavigation, (_event, _url, _isInPlace, isMainFrame) => {
+    if (!isMainFrame) {
+      return
+    }
+    shouldRestoreParentFocus = parentWebContents.isFocused()
+  })
+
+  webContents.on(ElectronWebContentsEventType.DidNavigate, () => {
+    if (!shouldRestoreParentFocus) {
+      return
+    }
+    shouldRestoreParentFocus = false
+    parentWebContents.focus()
+  })
+}

--- a/packages/main-process/test/ElectronWebContentsViewNavigationFocus.test.ts
+++ b/packages/main-process/test/ElectronWebContentsViewNavigationFocus.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import * as ElectronWebContentsViewNavigationFocus from '../src/parts/ElectronWebContentsViewNavigationFocus/ElectronWebContentsViewNavigationFocus.ts'
+
+let didNavigateListener: any
+let didStartNavigationListener: any
+
+const webContents = {
+  on: jest.fn((event: string, listener: any) => {
+    if (event === 'did-start-navigation') {
+      didStartNavigationListener = listener
+    } else if (event === 'did-navigate') {
+      didNavigateListener = listener
+    }
+  }),
+}
+
+const parentWebContents = {
+  focus: jest.fn(),
+  isFocused: jest.fn(),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  parentWebContents.isFocused.mockReset()
+  didNavigateListener = undefined
+  didStartNavigationListener = undefined
+  ElectronWebContentsViewNavigationFocus.attach(webContents as any, parentWebContents as any)
+})
+
+test('restores parent focus after a background main-frame navigation', () => {
+  parentWebContents.isFocused.mockReturnValue(true)
+
+  didStartNavigationListener({}, 'http://localhost:5173', false, true)
+  didNavigateListener()
+
+  expect(parentWebContents.focus).toHaveBeenCalledTimes(1)
+})
+
+test('preserves preview focus after an intentional navigation', () => {
+  parentWebContents.isFocused.mockReturnValue(false)
+
+  didStartNavigationListener({}, 'http://localhost:5173', false, true)
+  didNavigateListener()
+
+  expect(parentWebContents.focus).not.toHaveBeenCalled()
+})
+
+test('ignores subframe navigation when the parent owned focus', () => {
+  parentWebContents.isFocused.mockReturnValue(true)
+
+  didStartNavigationListener({}, 'http://localhost:5173', false, true)
+  didStartNavigationListener({}, 'http://localhost:5173/frame', false, false)
+  didNavigateListener()
+
+  expect(parentWebContents.focus).toHaveBeenCalledTimes(1)
+})
+
+test('does not reuse focus state from an earlier navigation', () => {
+  parentWebContents.isFocused.mockReturnValue(true)
+  didStartNavigationListener({}, 'http://localhost:5173', false, true)
+  didNavigateListener()
+
+  parentWebContents.isFocused.mockReturnValue(false)
+  didStartNavigationListener({}, 'http://localhost:5173/next', false, true)
+  didNavigateListener()
+
+  expect(parentWebContents.focus).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
## Summary

- remember whether the main editor web contents owned focus when an embedded preview starts a main-frame navigation
- restore that focus after the preview navigation completes
- preserve intentional preview focus and ignore subframe navigation

## Verification

- focused Jest coverage for focus restoration and preservation cases
- type-check
- lint
- built and exercised in the official LVCE Electron UI with a Vite live preview; typing remains active after save-triggered reload